### PR TITLE
update manual validation job condition

### DIFF
--- a/devops-pipelines/templates/backend-deploy-stages.yml
+++ b/devops-pipelines/templates/backend-deploy-stages.yml
@@ -39,7 +39,7 @@ parameters:
 stages:
 - stage: Approve_Deployment_${{ parameters.environment }}
   displayName: '${{ parameters.environment }} - Approve Deployment'
-  condition: ${{ eq(parameters.requireValidation, true) }}
+  condition: and(succeeded(), ${{ eq(parameters.requireValidation, true) }})
   jobs:
   - template: ./manual-validation-jobs.yml
     parameters:

--- a/devops-pipelines/templates/ui-build-and-deploy-stages.yml
+++ b/devops-pipelines/templates/ui-build-and-deploy-stages.yml
@@ -35,7 +35,7 @@ parameters:
 stages:
 - stage: Approve_Deployment_${{ parameters.environment }}
   displayName: 'CM ${{ parameters.environment }} - Approve Deployment'
-  condition: ${{ eq(parameters.requireValidation, true) }}
+  condition: and(succeeded(), ${{ eq(parameters.requireValidation, true) }})
   jobs:
   - template: ./manual-validation-jobs.yml
     parameters:


### PR DESCRIPTION
Issue addressed:
Cancelling a deployment pipeline run in the dev stage, would still run the 'manual_validation' job for staging unnecessarily.