### PR TITLE
FCT2-17947: add Playwright e2e suite for Register a Case

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -309,6 +309,13 @@ src/ui-spa/playwright/.cache/
 src/ui-spa/playwright/.auth/
 src/ui-spa/integration-test-results.xml
 
+# Playwright e2e (src/ui-spa/e2e-tests)
+src/ui-spa/e2e-tests/.auth/
+src/ui-spa/e2e-tests/playwright-report/
+src/ui-spa/e2e-tests/test-results/
+src/ui-spa/e2e-tests/e2e-test-results.xml
+src/ui-spa/e2e-tests/.env.e2e.local
+
 # Vite
 ui-spa/.vite/deps/
 

--- a/src/ui-spa/e2e-tests/.env.e2e.local.example
+++ b/src/ui-spa/e2e-tests/.env.e2e.local.example
@@ -1,0 +1,12 @@
+# Copy to .env.e2e.local (gitignored) and fill in real credentials.
+# Used by e2e-tests/global-setup.ts.
+
+# Tactical CMS login (authenticates the API).
+E2E_CMS_USERNAME=
+E2E_CMS_PASSWORD=
+
+# Entra (Azure AD) sign-in for the deployed SPA. The username is the UPN/email
+# used at login.microsoftonline.com. The account must have dev access and no
+# enforced MFA / interactive conditional access for unattended automation.
+E2E_AAD_USERNAME=
+E2E_AAD_PASSWORD=

--- a/src/ui-spa/e2e-tests/.env.e2e.local.example
+++ b/src/ui-spa/e2e-tests/.env.e2e.local.example
@@ -1,6 +1,6 @@
 # Copy to .env.e2e.local (gitignored) and fill in real values.
-E2E_FRONTEND_URL=https://cmrc-app-ui-spa-dev.azurewebsites.net
-E2E_API_BASE_URL=https://fa-cmrc-api-dev.azurewebsites.net
+E2E_FRONTEND_URL=
+E2E_API_BASE_URL=
 E2E_CMS_USERNAME=
 E2E_CMS_PASSWORD=
 E2E_AAD_USERNAME=

--- a/src/ui-spa/e2e-tests/.env.e2e.local.example
+++ b/src/ui-spa/e2e-tests/.env.e2e.local.example
@@ -1,12 +1,7 @@
-# Copy to .env.e2e.local (gitignored) and fill in real credentials.
-# Used by e2e-tests/global-setup.ts.
-
-# Tactical CMS login (authenticates the API).
+# Copy to .env.e2e.local (gitignored) and fill in real values.
+E2E_FRONTEND_URL=https://cmrc-app-ui-spa-dev.azurewebsites.net
+E2E_API_BASE_URL=https://fa-cmrc-api-dev.azurewebsites.net
 E2E_CMS_USERNAME=
 E2E_CMS_PASSWORD=
-
-# Entra (Azure AD) sign-in for the deployed SPA. The username is the UPN/email
-# used at login.microsoftonline.com. The account must have dev access and no
-# enforced MFA / interactive conditional access for unattended automation.
 E2E_AAD_USERNAME=
 E2E_AAD_PASSWORD=

--- a/src/ui-spa/e2e-tests/README.md
+++ b/src/ui-spa/e2e-tests/README.md
@@ -1,0 +1,115 @@
+# Register a Case — end-to-end tests
+
+Playwright end-to-end suite that drives the **deployed dev SPA** against the
+**real backend** (gateway API + MDS). Unlike `integration-tests/`, nothing is
+mocked here — no `playwright-msw`, no stubbed APIs — so breakages in the gateway
+API, request/response contracts, validators, mappers or the MDS wiring are
+caught from the browser side.
+
+- Frontend under test: `https://cmrc-app-ui-spa-dev.azurewebsites.net`
+- Gateway API: `https://fa-cmrc-api-dev.azurewebsites.net`
+- Browser: Chromium only
+
+The existing `integration-tests/` suite is untouched and still runs as before.
+
+## Prerequisites
+
+- Node and dependencies installed (`npm install` in `src/ui-spa`).
+- Chromium installed for Playwright: `npx playwright install chromium`.
+- Network access to the dev environment (the deployed UI, the gateway API, and
+  `login.microsoftonline.com`).
+- Credentials (see below).
+
+## Credentials and configuration
+
+Secrets are read from `e2e-tests/.env.e2e.local` (gitignored). Copy
+`e2e-tests/.env.e2e.local.example` to `e2e-tests/.env.e2e.local` and fill it in
+(PowerShell: `Copy-Item e2e-tests/.env.e2e.local.example e2e-tests/.env.e2e.local`).
+
+Required:
+
+| Variable             | Purpose                                            |
+| -------------------- | -------------------------------------------------- |
+| `E2E_CMS_USERNAME`   | CMS user for the tactical login (authenticates API)|
+| `E2E_CMS_PASSWORD`   | CMS password                                       |
+| `E2E_AAD_USERNAME`   | Entra/Azure AD UPN (email) for the SPA sign-in     |
+| `E2E_AAD_PASSWORD`   | Entra/Azure AD password                            |
+
+The AAD account must have dev access and **no enforced MFA / interactive
+conditional access**, otherwise the unattended sign-in will stall.
+
+Optional overrides default to sensible values in `config.ts` / `journeys/steps.ts`,
+so the suite runs with only the credentials above. Set any of these in
+`e2e-tests/.env.e2e.local` (or the process environment) to override:
+
+`E2E_FRONTEND_URL`, `E2E_API_BASE_URL`, `E2E_AREA`, `E2E_REGISTERING_UNIT`,
+`E2E_WITNESS_CARE_UNIT`, `E2E_OPERATION_NAME`, `E2E_PROSECUTOR`,
+`E2E_CASEWORKER`, `E2E_INVESTIGATOR_FIRST_NAME`, `E2E_INVESTIGATOR_LAST_NAME`,
+`E2E_INVESTIGATOR_SHOULDER_NUMBER`.
+
+Prosecutor and caseworker are picked from the live API response for the
+registering unit when not overridden (the MSW defaults are not real dev data).
+
+## Running
+
+All commands run from `src/ui-spa`:
+
+```
+npm run e2e:test                                                  # headless
+npx playwright test --config=e2e-tests/playwright.e2e.config.ts --headed   # headed
+npm run e2e:test:ui                                               # Playwright UI mode
+npm run e2e:test:ci                                               # CI mode (CI=true)
+npm run e2e:report                                                # open the HTML report
+```
+
+The HTML report is written to `e2e-tests/playwright-report/`; JUnit results to
+`e2e-tests/e2e-test-results.xml`.
+
+## How authentication works
+
+Authentication happens once in `global-setup.ts`, in a single browser context:
+
+1. **Tactical CMS login** (`auth/tacticalLogin.ts`) — posts the CMS credentials
+   to `{API}/api/tactical/login`, which sets the `Cms-Auth-Values` cookie that
+   authenticates the gateway API.
+2. **Entra (Azure AD) sign-in** (`auth/aadLogin.ts`) — drives the Microsoft
+   sign-in for the deployed SPA, starting at the app root (the only registered
+   MSAL redirect URI).
+
+The resulting cookies are saved as Playwright `storageState`
+(`e2e-tests/.auth/state.json`, gitignored) and reused by every test via
+`use.storageState`. MSAL caches its tokens in `sessionStorage` (which
+storageState does not persist), so each test's `loginRedirect` completes
+silently via the saved SSO cookies.
+
+## Test data
+
+Each run creates **real cases** in the dev environment. Every test generates a
+unique URN (`utils/generateUrn.ts`, clock + randomness) so parallel runs do not
+clash. There is no automatic cleanup; cases are isolated by URN.
+
+## Structure
+
+```
+e2e-tests/
+  playwright.e2e.config.ts   Chromium, 120s timeout, HTML/JUnit/list reporters
+  global-setup.ts            tactical + AAD login -> storageState
+  config.ts                  env loading + URLs + credential accessors
+  auth/                      tacticalLogin, aadLogin
+  utils/                     expectStep, startRegistration, generateUrn
+  journeys/                  reusable end-to-end journeys (shortPath, steps,
+                             suspectNoCharges)
+  *.spec.ts                  the scenarios
+```
+
+Page Object Models are reused from `../integration-tests/pages`. Because those
+hardcode `http://localhost:5173` in `verifyUrl()`, the e2e suite asserts the
+current step with the origin-agnostic `utils/expectStep.ts` instead.
+
+## Known defect
+
+The pure short path with **no operation name and no suspect** is currently
+blocked by an SPA defect: selecting "No" for "Do you have an operation name?"
+with no suspect does not register in the form (the radio shows selected but Save
+reports an error). Scenario 1 covers the no-operation-name path **with a
+suspect**, which sidesteps the defect. Track the SPA fix separately.

--- a/src/ui-spa/e2e-tests/README.md
+++ b/src/ui-spa/e2e-tests/README.md
@@ -2,15 +2,12 @@
 
 Playwright end-to-end suite that drives the **deployed dev SPA** against the
 **real backend** (gateway API + MDS). Unlike `integration-tests/`, nothing is
-mocked here — no `playwright-msw`, no stubbed APIs — so breakages in the gateway
-API, request/response contracts, validators, mappers or the MDS wiring are
-caught from the browser side.
+mocked here — no `playwright-msw`, no stubbed APIs
 
-- Frontend under test: `https://cmrc-app-ui-spa-dev.azurewebsites.net`
-- Gateway API: `https://fa-cmrc-api-dev.azurewebsites.net`
+- Frontend under test and gateway API: set via `E2E_FRONTEND_URL` /
+  `E2E_API_BASE_URL` (see `.env.e2e.local.example` for starting values).
 - Browser: Chromium only
 
-The existing `integration-tests/` suite is untouched and still runs as before.
 
 ## Prerequisites
 
@@ -26,29 +23,20 @@ Secrets are read from `e2e-tests/.env.e2e.local` (gitignored). Copy
 `e2e-tests/.env.e2e.local.example` to `e2e-tests/.env.e2e.local` and fill it in
 (PowerShell: `Copy-Item e2e-tests/.env.e2e.local.example e2e-tests/.env.e2e.local`).
 
-Required:
+Required (no defaults — the suite throws if any are unset):
 
 | Variable             | Purpose                                            |
 | -------------------- | -------------------------------------------------- |
+| `E2E_FRONTEND_URL`   | SPA under test (e.g. the dev SPA)                  |
+| `E2E_API_BASE_URL`   | Gateway API base URL (e.g. the dev API)            |
 | `E2E_CMS_USERNAME`   | CMS user for the tactical login (authenticates API)|
 | `E2E_CMS_PASSWORD`   | CMS password                                       |
 | `E2E_AAD_USERNAME`   | Entra/Azure AD UPN (email) for the SPA sign-in     |
 | `E2E_AAD_PASSWORD`   | Entra/Azure AD password                            |
 
-The AAD account must have dev access and **no enforced MFA / interactive
-conditional access**, otherwise the unattended sign-in will stall.
+The URLs are required deliberately so a run can't silently target the wrong
+environment; starting values for dev are in `.env.e2e.local.example`.
 
-Optional overrides default to sensible values in `config.ts` / `journeys/steps.ts`,
-so the suite runs with only the credentials above. Set any of these in
-`e2e-tests/.env.e2e.local` (or the process environment) to override:
-
-`E2E_FRONTEND_URL`, `E2E_API_BASE_URL`, `E2E_AREA`, `E2E_REGISTERING_UNIT`,
-`E2E_WITNESS_CARE_UNIT`, `E2E_OPERATION_NAME`, `E2E_PROSECUTOR`,
-`E2E_CASEWORKER`, `E2E_INVESTIGATOR_FIRST_NAME`, `E2E_INVESTIGATOR_LAST_NAME`,
-`E2E_INVESTIGATOR_SHOULDER_NUMBER`.
-
-Prosecutor and caseworker are picked from the live API response for the
-registering unit when not overridden (the MSW defaults are not real dev data).
 
 ## Running
 
@@ -85,14 +73,10 @@ silently via the saved SSO cookies.
 ## Test data
 
 Each run creates **real cases** in the dev environment. Every test generates a
-URN (`utils/generateUrn.ts`) whose 5-digit reference combines the clock, the
-Playwright worker index and a CSPRNG value, so parallel workers and successive
-runs are very unlikely to clash. There is no automatic cleanup; cases are
-isolated by URN. Note the reference space is bounded (5 digits, the CMS URN
-format), so over a long-lived shared environment a generated URN could still
-collide with an existing case — a duplicate-URN retry/cleanup step is a possible
-future hardening (and the planned URN-duplicate-validation scenario will cover
-the error path explicitly).
+URN (`utils/generateUrn.ts`) whose 5-digit reference combines a millisecond
+timestamp (`Date.now()`), the Playwright worker index and a CSPRNG value, so
+parallel workers and successive runs are very unlikely to clash. There is no
+automatic cleanup; cases are isolated by URN.
 
 ## Structure
 
@@ -107,15 +91,3 @@ e2e-tests/
                              suspectNoCharges)
   *.spec.ts                  the scenarios
 ```
-
-Page Object Models are reused from `../integration-tests/pages`. Because those
-hardcode `http://localhost:5173` in `verifyUrl()`, the e2e suite asserts the
-current step with the origin-agnostic `utils/expectStep.ts` instead.
-
-## Known defect
-
-The pure short path with **no operation name and no suspect** is currently
-blocked by an SPA defect: selecting "No" for "Do you have an operation name?"
-with no suspect does not register in the form (the radio shows selected but Save
-reports an error). Scenario 1 covers the no-operation-name path **with a
-suspect**, which sidesteps the defect. Track the SPA fix separately.

--- a/src/ui-spa/e2e-tests/README.md
+++ b/src/ui-spa/e2e-tests/README.md
@@ -85,8 +85,14 @@ silently via the saved SSO cookies.
 ## Test data
 
 Each run creates **real cases** in the dev environment. Every test generates a
-unique URN (`utils/generateUrn.ts`, clock + randomness) so parallel runs do not
-clash. There is no automatic cleanup; cases are isolated by URN.
+URN (`utils/generateUrn.ts`) whose 5-digit reference combines the clock, the
+Playwright worker index and a CSPRNG value, so parallel workers and successive
+runs are very unlikely to clash. There is no automatic cleanup; cases are
+isolated by URN. Note the reference space is bounded (5 digits, the CMS URN
+format), so over a long-lived shared environment a generated URN could still
+collide with an existing case — a duplicate-URN retry/cleanup step is a possible
+future hardening (and the planned URN-duplicate-validation scenario will cover
+the error path explicitly).
 
 ## Structure
 

--- a/src/ui-spa/e2e-tests/README.md
+++ b/src/ui-spa/e2e-tests/README.md
@@ -35,7 +35,8 @@ Required (no defaults — the suite throws if any are unset):
 | `E2E_AAD_PASSWORD`   | Entra/Azure AD password                            |
 
 The URLs are required deliberately so a run can't silently target the wrong
-environment; starting values for dev are in `.env.e2e.local.example`.
+environment; set them for your target environment in `.env.e2e.local`
+(see `.env.e2e.local.example` for the template).
 
 
 ## Running

--- a/src/ui-spa/e2e-tests/auth/aadLogin.ts
+++ b/src/ui-spa/e2e-tests/auth/aadLogin.ts
@@ -1,0 +1,38 @@
+import { expect, type Page } from "@playwright/test";
+
+export interface AadLoginOptions {
+  appUrl: string;
+  username: string;
+  password: string;
+}
+
+export async function aadLogin(
+  page: Page,
+  { appUrl, username, password }: AadLoginOptions,
+): Promise<void> {
+  await page.goto(`${appUrl}/`);
+
+  const email = page.locator('input[name="loginfmt"]');
+  await email.waitFor({ state: "visible", timeout: 30_000 });
+  await email.fill(username);
+  await page.click("#idSIButton9");
+
+  const passwordInput = page.locator('input[name="passwd"]');
+  await passwordInput.waitFor({ state: "visible", timeout: 30_000 });
+  await passwordInput.fill(password);
+  await page.click("#idSIButton9");
+
+  const kmsiHeading = page.getByRole("heading", { name: /stay signed in/i });
+  const kmsiShown = await kmsiHeading
+    .waitFor({ state: "visible", timeout: 20_000 })
+    .then(() => true)
+    .catch(() => false);
+  if (kmsiShown) {
+    await page.click("#idSIButton9");
+  }
+
+  await expect(
+    page.getByRole("heading", { name: "Register a case" }),
+    "MSAL sign-in did not land on the Register a case page (check AAD creds / group access / MFA)",
+  ).toBeVisible({ timeout: 60_000 });
+}

--- a/src/ui-spa/e2e-tests/auth/tacticalLogin.ts
+++ b/src/ui-spa/e2e-tests/auth/tacticalLogin.ts
@@ -1,0 +1,21 @@
+import { expect, type Page } from "@playwright/test";
+
+export interface TacticalLoginOptions {
+  apiBaseUrl: string;
+  username: string;
+  password: string;
+}
+
+export async function tacticalLogin(
+  page: Page,
+  { apiBaseUrl, username, password }: TacticalLoginOptions,
+): Promise<void> {
+  await page.goto(`${apiBaseUrl}/api/tactical/login`);
+  await page.locator("input[name='username']").fill(username);
+  await page.locator("input[name='password']").fill(password);
+  await page.getByRole("button", { name: "Log in" }).click();
+  await expect(
+    page.getByTestId("login-ok"),
+    "Tactical CMS login failed — check E2E_CMS_USERNAME / E2E_CMS_PASSWORD in .env.e2e.local",
+  ).toBeVisible();
+}

--- a/src/ui-spa/e2e-tests/config.ts
+++ b/src/ui-spa/e2e-tests/config.ts
@@ -17,12 +17,9 @@ const required = (name: string): string => {
   return value;
 };
 
-export const FRONTEND_URL =
-  process.env.E2E_FRONTEND_URL ??
-  "https://cmrc-app-ui-spa-dev.azurewebsites.net";
+export const FRONTEND_URL = required("E2E_FRONTEND_URL");
 
-export const API_BASE_URL =
-  process.env.E2E_API_BASE_URL ?? "https://fa-cmrc-api-dev.azurewebsites.net";
+export const API_BASE_URL = required("E2E_API_BASE_URL");
 
 export const getCmsCredentials = () => ({
   username: required("E2E_CMS_USERNAME"),

--- a/src/ui-spa/e2e-tests/config.ts
+++ b/src/ui-spa/e2e-tests/config.ts
@@ -1,0 +1,35 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import dotenv from "dotenv";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+dotenv.config({ path: path.join(here, ".env.e2e.local") });
+
+export const STORAGE_STATE = path.join(here, ".auth", "state.json");
+
+const required = (name: string): string => {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(
+      `Missing required env var ${name}. Set it in e2e-tests/.env.e2e.local`,
+    );
+  }
+  return value;
+};
+
+export const FRONTEND_URL =
+  process.env.E2E_FRONTEND_URL ??
+  "https://cmrc-app-ui-spa-dev.azurewebsites.net";
+
+export const API_BASE_URL =
+  process.env.E2E_API_BASE_URL ?? "https://fa-cmrc-api-dev.azurewebsites.net";
+
+export const getCmsCredentials = () => ({
+  username: required("E2E_CMS_USERNAME"),
+  password: required("E2E_CMS_PASSWORD"),
+});
+
+export const getAadCredentials = () => ({
+  username: required("E2E_AAD_USERNAME"),
+  password: required("E2E_AAD_PASSWORD"),
+});

--- a/src/ui-spa/e2e-tests/global-setup.ts
+++ b/src/ui-spa/e2e-tests/global-setup.ts
@@ -1,0 +1,37 @@
+import fs from "node:fs";
+import path from "node:path";
+import { chromium } from "@playwright/test";
+import { tacticalLogin } from "./auth/tacticalLogin";
+import { aadLogin } from "./auth/aadLogin";
+import {
+  API_BASE_URL,
+  FRONTEND_URL,
+  STORAGE_STATE,
+  getAadCredentials,
+  getCmsCredentials,
+} from "./config";
+
+async function globalSetup(): Promise<void> {
+  const browser = await chromium.launch();
+  try {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+
+    await tacticalLogin(page, {
+      apiBaseUrl: API_BASE_URL,
+      ...getCmsCredentials(),
+    });
+
+    await aadLogin(page, {
+      appUrl: FRONTEND_URL,
+      ...getAadCredentials(),
+    });
+
+    fs.mkdirSync(path.dirname(STORAGE_STATE), { recursive: true });
+    await context.storageState({ path: STORAGE_STATE });
+  } finally {
+    await browser.close();
+  }
+}
+
+export default globalSetup;

--- a/src/ui-spa/e2e-tests/journeys/shortPath.ts
+++ b/src/ui-spa/e2e-tests/journeys/shortPath.ts
@@ -1,0 +1,22 @@
+import { type Page } from "@playwright/test";
+import { generateUniqueUrn } from "../utils/generateUrn";
+import {
+  startAtHomePage,
+  enterAreasAndCaseDetails,
+  completeAssigneeAndSubmit,
+} from "./steps";
+
+export interface ShortPathOptions {
+  operationName?: string;
+}
+
+export async function completeShortPath(
+  page: Page,
+  { operationName }: ShortPathOptions = {},
+): Promise<void> {
+  const urn = generateUniqueUrn();
+
+  await startAtHomePage(page, { operationName, hasSuspect: false });
+  await enterAreasAndCaseDetails(page, urn);
+  await completeAssigneeAndSubmit(page, urn, operationName);
+}

--- a/src/ui-spa/e2e-tests/journeys/shortPath.ts
+++ b/src/ui-spa/e2e-tests/journeys/shortPath.ts
@@ -7,12 +7,15 @@ import {
 } from "./steps";
 
 export interface ShortPathOptions {
-  operationName?: string;
+  // Required: the no-suspect short path is only valid with an operation name.
+  // Omitting it would select No for both operation name and suspect details,
+  // which the UI correctly rejects.
+  operationName: string;
 }
 
 export async function completeShortPath(
   page: Page,
-  { operationName }: ShortPathOptions = {},
+  { operationName }: ShortPathOptions,
 ): Promise<void> {
   const urn = generateUniqueUrn();
 

--- a/src/ui-spa/e2e-tests/journeys/steps.ts
+++ b/src/ui-spa/e2e-tests/journeys/steps.ts
@@ -1,0 +1,153 @@
+import { expect, type Page } from "@playwright/test";
+import { CaseRegistrationHomePage } from "../../integration-tests/pages/caseRegistrationHomePage";
+import { CaseAreasPage } from "../../integration-tests/pages/caseAreasPage";
+import { CaseDetailsPage } from "../../integration-tests/pages/caseDetailsPage";
+import { CaseMonitoringPage } from "../../integration-tests/pages/caseMonitoringPage";
+import { CaseAssigneePage } from "../../integration-tests/pages/caseAssigneePage";
+import { CaseRegistrationSummaryPage } from "../../integration-tests/pages/caseRegistrationSummaryPage";
+import { expectStep } from "../utils/expectStep";
+import { startRegistration } from "../utils/startRegistration";
+import type { UrnParts } from "../utils/generateUrn";
+
+const AREA = process.env.E2E_AREA ?? "CAMBRIDGESHIRE";
+const REGISTERING_UNIT =
+  process.env.E2E_REGISTERING_UNIT ?? "NORTHERN CJU (Peterborough)";
+const WITNESS_CARE_UNIT =
+  process.env.E2E_WITNESS_CARE_UNIT ?? "Cambridgeshire Non Operational WCU";
+
+const PROSECUTOR = process.env.E2E_PROSECUTOR;
+const CASEWORKER = process.env.E2E_CASEWORKER;
+const INVESTIGATOR_FIRST_NAME =
+  process.env.E2E_INVESTIGATOR_FIRST_NAME ?? "InvestigatorF";
+const INVESTIGATOR_LAST_NAME =
+  process.env.E2E_INVESTIGATOR_LAST_NAME ?? "InvestigatorL";
+const INVESTIGATOR_SHOULDER_NUMBER =
+  process.env.E2E_INVESTIGATOR_SHOULDER_NUMBER ?? "12345";
+
+export interface HomePageOptions {
+  operationName?: string;
+  hasSuspect: boolean;
+}
+
+export async function startAtHomePage(
+  page: Page,
+  { operationName, hasSuspect }: HomePageOptions,
+): Promise<void> {
+  await startRegistration(page);
+  await expect(page).toHaveTitle(/Case Management Register a Case/);
+
+  const homePage = new CaseRegistrationHomePage(page);
+  await expectStep(page, "/case-registration");
+  if (operationName) {
+    await homePage.addOperationName(operationName);
+  } else {
+    await homePage.addNoOperationName();
+  }
+  if (hasSuspect) {
+    await homePage.addSuspect();
+  } else {
+    await homePage.addNoSuspect();
+  }
+  await homePage.saveAndContinue();
+}
+
+export async function enterAreasAndCaseDetails(
+  page: Page,
+  urn: UrnParts,
+): Promise<void> {
+  const areasPage = new CaseAreasPage(page);
+  await expectStep(page, "/case-registration/areas");
+  await areasPage.enterAreaOrDivision(AREA);
+  await areasPage.saveAndContinue();
+
+  const detailsPage = new CaseDetailsPage(page);
+  await expectStep(page, "/case-registration/case-details");
+  await detailsPage.enterUrnPoliceForce(urn.policeForce);
+  await detailsPage.enterUrnPoliceUnit(urn.policeUnit);
+  await detailsPage.enterUrnUniqueReference(urn.uniqueReference);
+  await detailsPage.enterUrnYearReference(urn.yearReference);
+  await detailsPage.enterRegisteringUnit(REGISTERING_UNIT);
+  await detailsPage.enterWitnessCareUnit(WITNESS_CARE_UNIT);
+  await detailsPage.saveAndContinue();
+}
+
+export async function completeAssigneeAndSubmit(
+  page: Page,
+  urn: UrnParts,
+  operationName?: string,
+): Promise<void> {
+  const monitoringPage = new CaseMonitoringPage(page);
+  await expectStep(page, "/case-registration/case-monitoring-codes");
+  await monitoringPage.verifyPreChargeCheckboxChecked();
+
+  const prosecutorsResponse = page.waitForResponse(
+    (r) => /\/api\/v1\/prosecutors\//.test(r.url()) && r.ok(),
+    { timeout: 30_000 },
+  );
+  const caseworkersResponse = page.waitForResponse(
+    (r) => /\/api\/v1\/caseworkers\//.test(r.url()) && r.ok(),
+    { timeout: 30_000 },
+  );
+  await monitoringPage.saveAndContinue();
+
+  const assigneePage = new CaseAssigneePage(page);
+  await expectStep(page, "/case-registration/case-assignee");
+  await assigneePage.addProsecutorYes();
+  await assigneePage.addInvestigatorYes();
+
+  const prosecutors = (await (await prosecutorsResponse).json()) as {
+    description: string;
+  }[];
+  const caseworkers = (await (await caseworkersResponse).json()) as {
+    description: string;
+  }[];
+  const prosecutorName = PROSECUTOR ?? prosecutors[0]?.description;
+  const caseworkerName = CASEWORKER ?? caseworkers[0]?.description;
+  expect(
+    prosecutorName,
+    "no prosecutors returned for the registering unit",
+  ).toBeTruthy();
+  expect(
+    caseworkerName,
+    "no caseworkers returned for the registering unit",
+  ).toBeTruthy();
+
+  await assigneePage.enterProsecutorName(prosecutorName);
+  await assigneePage.enterCaseworkerName(caseworkerName);
+  await assigneePage.addInvestigatorFirstName(INVESTIGATOR_FIRST_NAME);
+  await assigneePage.addInvestigatorLastName(INVESTIGATOR_LAST_NAME);
+  await assigneePage.addInvestigatorShoulderNumber(
+    INVESTIGATOR_SHOULDER_NUMBER,
+  );
+  await assigneePage.saveAndContinue();
+
+  const summaryPage = new CaseRegistrationSummaryPage(page);
+  await expectStep(page, "/case-registration/case-summary");
+  await summaryPage.verifyCaseDetailsElements({
+    area: AREA,
+    urn: urn.formatted,
+    registeringUnit: REGISTERING_UNIT,
+    wcu: WITNESS_CARE_UNIT,
+    operationName: operationName ?? "Not entered",
+  });
+
+  const registerCaseResponsePromise = page.waitForResponse(
+    (response) =>
+      response.url().endsWith("/api/v1/cases") &&
+      response.request().method() === "POST",
+  );
+
+  await summaryPage.clickCreateCaseButton();
+
+  const registerCaseResponse = await registerCaseResponsePromise;
+  expect(
+    registerCaseResponse.ok(),
+    `POST /api/v1/cases returned ${registerCaseResponse.status()}`,
+  ).toBe(true);
+
+  await expectStep(page, "/case-registration/case-registration-confirmation");
+  await expect(
+    page.getByRole("heading", { name: "Case registered successfully" }),
+  ).toBeVisible();
+  await expect(page.getByText(urn.formatted, { exact: false })).toBeVisible();
+}

--- a/src/ui-spa/e2e-tests/journeys/suspectNoCharges.ts
+++ b/src/ui-spa/e2e-tests/journeys/suspectNoCharges.ts
@@ -1,0 +1,46 @@
+import { expect, type Page } from "@playwright/test";
+import { AddSuspectPage } from "../../integration-tests/pages/addSuspectPage";
+import { SuspectSummaryPage } from "../../integration-tests/pages/suspectSummaryPage";
+import { WantToAddChargesPage } from "../../integration-tests/pages/wantToAddChargesPage";
+import { generateUniqueUrn } from "../utils/generateUrn";
+import { expectStep } from "../utils/expectStep";
+import {
+  startAtHomePage,
+  enterAreasAndCaseDetails,
+  completeAssigneeAndSubmit,
+} from "./steps";
+
+export interface SuspectNoChargesOptions {
+  operationName?: string;
+}
+
+export async function completeSuspectNoChargesPath(
+  page: Page,
+  { operationName }: SuspectNoChargesOptions = {},
+): Promise<void> {
+  const urn = generateUniqueUrn();
+
+  await startAtHomePage(page, { operationName, hasSuspect: true });
+  await enterAreasAndCaseDetails(page, urn);
+
+  const addSuspectPage = new AddSuspectPage(page);
+  await expect(page).toHaveURL(
+    /^https?:\/\/[^/]+\/case-registration\/[^/]+\/add-suspect\/?$/,
+  );
+  await addSuspectPage.addPersonSuspect();
+  await addSuspectPage.addSuspectFirstName("Harry");
+  await addSuspectPage.addSuspectLastName("Potter");
+  await addSuspectPage.saveAndContinue();
+
+  const suspectSummaryPage = new SuspectSummaryPage(page);
+  await expectStep(page, "/case-registration/suspect-summary");
+  await suspectSummaryPage.selectAddMoreSuspectNo();
+  await suspectSummaryPage.saveAndContinue();
+
+  const wantToAddChargesPage = new WantToAddChargesPage(page);
+  await expectStep(page, "/case-registration/want-to-add-charges");
+  await wantToAddChargesPage.selectAddChargesNo();
+  await wantToAddChargesPage.saveAndContinue();
+
+  await completeAssigneeAndSubmit(page, urn, operationName);
+}

--- a/src/ui-spa/e2e-tests/playwright.e2e.config.ts
+++ b/src/ui-spa/e2e-tests/playwright.e2e.config.ts
@@ -1,0 +1,30 @@
+import { defineConfig, devices } from "@playwright/test";
+import { FRONTEND_URL, STORAGE_STATE } from "./config";
+
+export default defineConfig({
+  timeout: 120000,
+  testDir: ".",
+  globalSetup: "./global-setup.ts",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: [
+    ["list"],
+    ["html", { outputFolder: "./playwright-report", open: "never" }],
+    ["junit", { outputFile: "./e2e-test-results.xml" }],
+  ],
+  use: {
+    baseURL: FRONTEND_URL,
+    storageState: STORAGE_STATE,
+    trace: "on-first-retry",
+    video: "on",
+    screenshot: "only-on-failure",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+});

--- a/src/ui-spa/e2e-tests/short-path-no-operation-name.spec.ts
+++ b/src/ui-spa/e2e-tests/short-path-no-operation-name.spec.ts
@@ -1,0 +1,8 @@
+import { test } from "@playwright/test";
+import { completeSuspectNoChargesPath } from "./journeys/suspectNoCharges";
+
+test("Scenario 1: no operation name with a suspect, submits to /api/v1/cases", async ({
+  page,
+}) => {
+  await completeSuspectNoChargesPath(page, {});
+});

--- a/src/ui-spa/e2e-tests/short-path-with-operation-name.spec.ts
+++ b/src/ui-spa/e2e-tests/short-path-with-operation-name.spec.ts
@@ -1,0 +1,10 @@
+import { test } from "@playwright/test";
+import { completeShortPath } from "./journeys/shortPath";
+
+const OPERATION_NAME = process.env.E2E_OPERATION_NAME ?? "thunderstruck";
+
+test("Scenario 2: short path with an operation name, submits to /api/v1/cases", async ({
+  page,
+}) => {
+  await completeShortPath(page, { operationName: OPERATION_NAME });
+});

--- a/src/ui-spa/e2e-tests/utils/expectStep.ts
+++ b/src/ui-spa/e2e-tests/utils/expectStep.ts
@@ -1,0 +1,13 @@
+import { expect, type Page } from "@playwright/test";
+
+const escapeRegExp = (value: string): string =>
+  value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+export const expectStep = async (
+  page: Page,
+  pathname: string,
+): Promise<void> => {
+  await expect(page).toHaveURL(
+    new RegExp(`^https?://[^/]+${escapeRegExp(pathname)}/?(\\?.*)?$`),
+  );
+};

--- a/src/ui-spa/e2e-tests/utils/generateUrn.ts
+++ b/src/ui-spa/e2e-tests/utils/generateUrn.ts
@@ -1,0 +1,25 @@
+export interface UrnParts {
+  policeForce: string;
+  policeUnit: string;
+  uniqueReference: string;
+  yearReference: string;
+  formatted: string;
+}
+
+export const generateUniqueUrn = (
+  policeForce = "12",
+  policeUnit = "21",
+  year = "26",
+): UrnParts => {
+  const workerIndex = Number(process.env.TEST_WORKER_INDEX ?? "0") % 10;
+  const uniqueReference = String(
+    workerIndex * 10000 + Math.floor(Math.random() * 10000),
+  ).padStart(5, "0");
+  return {
+    policeForce,
+    policeUnit,
+    uniqueReference,
+    yearReference: year,
+    formatted: `${policeForce}${policeUnit}${uniqueReference}/${year}`,
+  };
+};

--- a/src/ui-spa/e2e-tests/utils/generateUrn.ts
+++ b/src/ui-spa/e2e-tests/utils/generateUrn.ts
@@ -1,3 +1,5 @@
+import { randomInt } from "node:crypto";
+
 export interface UrnParts {
   policeForce: string;
   policeUnit: string;
@@ -13,7 +15,7 @@ export const generateUniqueUrn = (
 ): UrnParts => {
   const workerIndex = Number(process.env.TEST_WORKER_INDEX ?? "0") % 10;
   const uniqueReference = String(
-    workerIndex * 10000 + Math.floor(Math.random() * 10000),
+    workerIndex * 10000 + randomInt(10000),
   ).padStart(5, "0");
   return {
     policeForce,

--- a/src/ui-spa/e2e-tests/utils/generateUrn.ts
+++ b/src/ui-spa/e2e-tests/utils/generateUrn.ts
@@ -13,9 +13,9 @@ export const generateUniqueUrn = (
   policeUnit = "21",
   year = "26",
 ): UrnParts => {
-  const workerIndex = Number(process.env.TEST_WORKER_INDEX ?? "0") % 10;
+  const workerIndex = Number(process.env.TEST_WORKER_INDEX ?? "0");
   const uniqueReference = String(
-    workerIndex * 10000 + randomInt(10000),
+    (Date.now() + workerIndex * 13 + randomInt(100000)) % 100000,
   ).padStart(5, "0");
   return {
     policeForce,

--- a/src/ui-spa/e2e-tests/utils/startRegistration.ts
+++ b/src/ui-spa/e2e-tests/utils/startRegistration.ts
@@ -1,0 +1,13 @@
+import { expect, type Page } from "@playwright/test";
+
+export const startRegistration = async (page: Page): Promise<void> => {
+  const unitsLoaded = page.waitForResponse(
+    (r) => r.url().includes("/api/v1/units") && r.request().method() === "GET",
+    { timeout: 60_000 },
+  );
+  await page.goto("/");
+  await expect(
+    page.getByRole("heading", { name: "Register a case" }),
+  ).toBeVisible({ timeout: 30_000 });
+  await unitsLoaded;
+};

--- a/src/ui-spa/package.json
+++ b/src/ui-spa/package.json
@@ -16,7 +16,11 @@
     "integration:test:ci": "tsc -b && vite build --mode playwright && cross-env CI=true npx playwright test",
     "integration:report": "npx playwright show-report ./playwright-report",
     "integration:coverage": "rimraf coverage/.nyc_output && cross-env ISTANBUL_COVERAGE=1 npm run integration:test:ci",
-    "integration:coverage:cobertura": "npm run integration:coverage && npx nyc report -t coverage/.nyc_output -r cobertura --report-dir coverage/integration"
+    "integration:coverage:cobertura": "npm run integration:coverage && npx nyc report -t coverage/.nyc_output -r cobertura --report-dir coverage/integration",
+    "e2e:test": "npx playwright test --config=e2e-tests/playwright.e2e.config.ts",
+    "e2e:test:ci": "cross-env CI=true npx playwright test --config=e2e-tests/playwright.e2e.config.ts",
+    "e2e:test:ui": "npx playwright test --config=e2e-tests/playwright.e2e.config.ts --ui",
+    "e2e:report": "npx playwright show-report ./e2e-tests/playwright-report"
   },
   "dependencies": {
     "@azure/msal-browser": "^4.4.0",


### PR DESCRIPTION
Adds an end-to-end Playwright suite

- Scenario 1: no operation name with a suspect (no charges). Scenario 2: short path with an operation name. 


<img width="1241" height="421" alt="Capturecmrcreport" src="https://github.com/user-attachments/assets/99b1e554-2e1c-45db-a39c-6c80b02ee17f" />
<img width="846" height="424" alt="Capturecmrcevidence" src="https://github.com/user-attachments/assets/18dc06c6-7ff2-4797-b964-1f72dc909a57" />
