### PR TITLE
adding scenarios for longpath duplicate victim and multisuspect

### DIFF
--- a/src/ui-spa/e2e-tests/journeys/longPathDuplicateVictim.ts
+++ b/src/ui-spa/e2e-tests/journeys/longPathDuplicateVictim.ts
@@ -1,5 +1,7 @@
 import { type Page } from "@playwright/test";
+import { AddChargeSuspectPage } from "../../integration-tests/pages/addChargeSuspectPage";
 import { ChargesSummaryPage } from "../../integration-tests/pages/chargesSummaryPage";
+import { ChargesVictimDuplicateConfirmationPage } from "../../integration-tests/pages/chargesVictimDuplicateConfirmation";
 import { generateUniqueUrn } from "../utils/generateUrn";
 import { expectStep } from "../utils/expectStep";
 import {
@@ -18,16 +20,18 @@ import {
 } from "./suspectChargeSteps";
 
 const OFFENCE_CODE = process.env.E2E_OFFENCE_CODE ?? "TH68040";
+const OFFENCE_CODE_2 = process.env.E2E_OFFENCE_CODE_2 ?? "TH68066";
 
-export interface LongPathSuspectChargeOptions {
+export interface LongPathDuplicateVictimOptions {
   operationName: string;
 }
 
-export async function completeLongPathSuspectCharge(
+export async function completeLongPathDuplicateVictim(
   page: Page,
-  { operationName }: LongPathSuspectChargeOptions,
+  { operationName }: LongPathDuplicateVictimOptions,
 ): Promise<void> {
   const urn = generateUniqueUrn();
+  const victim = personName();
   const { offence, arrestDate } = chargeDates();
 
   await startSingleSuspectUpToCharges(page, { operationName, urn, arrestDate });
@@ -38,11 +42,38 @@ export async function completeLongPathSuspectCharge(
     offenceCode: OFFENCE_CODE,
     dates: offence,
     chargedWithAdult: true,
-    victim: { mode: "new", name: personName() },
+    victim: { mode: "new", name: victim },
     hasExistingVictims: false,
   });
 
   const chargesSummaryPage = new ChargesSummaryPage(page);
+  await expectStep(page, "/case-registration/charges-summary");
+  await chargesSummaryPage.selectAddMoreChargesYes();
+  await chargesSummaryPage.saveAndContinue();
+
+  const addChargeSuspectPage = new AddChargeSuspectPage(page);
+  await expectStep(page, "/case-registration/add-charge-suspect");
+  await addChargeSuspectPage.selectSuspectByIndex(0);
+  await addChargeSuspectPage.saveAndContinue();
+
+  await addCharge(page, {
+    suspectIndex: 0,
+    chargeIndex: 1,
+    offenceCode: OFFENCE_CODE_2,
+    dates: offence,
+    chargedWithAdult: true,
+    victim: { mode: "new", name: victim },
+    hasExistingVictims: true,
+  });
+
+  const duplicateVictimPage = new ChargesVictimDuplicateConfirmationPage(page);
+  await expectStep(
+    page,
+    "/case-registration/charges-victim-duplicate-confirmation",
+  );
+  await duplicateVictimPage.verifyPageElements();
+  await duplicateVictimPage.saveAndContinue();
+
   await expectStep(page, "/case-registration/charges-summary");
   await chargesSummaryPage.selectAddMoreChargesNo();
   await completeFirstHearing(page, () => chargesSummaryPage.saveAndContinue());

--- a/src/ui-spa/e2e-tests/journeys/longPathMultiSuspectCharge.ts
+++ b/src/ui-spa/e2e-tests/journeys/longPathMultiSuspectCharge.ts
@@ -98,7 +98,7 @@ export async function completeLongPathMultiSuspectCharge(
     offenceCode: OFFENCE_CODE_2,
     dates,
     chargedWithAdult: true,
-    victim: { mode: "reuse" },
+    victim: { mode: "reuse", expectVictim: victim0 },
     hasExistingVictims: true,
   });
   await expectStep(page, "/case-registration/charges-summary");

--- a/src/ui-spa/e2e-tests/journeys/longPathMultiSuspectCharge.ts
+++ b/src/ui-spa/e2e-tests/journeys/longPathMultiSuspectCharge.ts
@@ -1,0 +1,149 @@
+import { expect, type Page } from "@playwright/test";
+import { SuspectSummaryPage } from "../../integration-tests/pages/suspectSummaryPage";
+import { WantToAddChargesPage } from "../../integration-tests/pages/wantToAddChargesPage";
+import { AddChargeSuspectPage } from "../../integration-tests/pages/addChargeSuspectPage";
+import { ChargesSummaryPage } from "../../integration-tests/pages/chargesSummaryPage";
+import { generateUniqueUrn } from "../utils/generateUrn";
+import { expectStep } from "../utils/expectStep";
+import {
+  AREA,
+  REGISTERING_UNIT,
+  WITNESS_CARE_UNIT,
+  startAtHomePage,
+  enterAreasAndCaseDetails,
+  completeMonitoringAndAssignee,
+  verifySummaryAndSubmit,
+} from "./steps";
+import {
+  personName,
+  chargeDates,
+  addPersonSuspectWithAllDetails,
+  addCharge,
+  completeFirstHearing,
+} from "./suspectChargeSteps";
+
+const OFFENCE_CODE = process.env.E2E_OFFENCE_CODE ?? "TH68040";
+const OFFENCE_CODE_2 = process.env.E2E_OFFENCE_CODE_2 ?? "TH68066";
+
+export interface LongPathMultiSuspectChargeOptions {
+  operationName: string;
+}
+
+export async function completeLongPathMultiSuspectCharge(
+  page: Page,
+  { operationName }: LongPathMultiSuspectChargeOptions,
+): Promise<void> {
+  const urn = generateUniqueUrn();
+  const suspect0 = personName();
+  const suspect1 = personName();
+  const victim0 = personName();
+  const victim1 = personName();
+
+  const { offence: dates, arrestDate } = chargeDates();
+
+  await startAtHomePage(page, { operationName, hasSuspect: true });
+  await enterAreasAndCaseDetails(page, urn);
+
+  const suspectSummaryPage = new SuspectSummaryPage(page);
+
+  await addPersonSuspectWithAllDetails(page, 0, {
+    name: suspect0,
+    alias: personName(),
+    arrestDate,
+  });
+  await expectStep(page, "/case-registration/suspect-summary");
+  await suspectSummaryPage.selectAddMoreSuspectYes();
+  await suspectSummaryPage.saveAndContinue();
+
+  await addPersonSuspectWithAllDetails(page, 1, {
+    name: suspect1,
+    alias: personName(),
+    arrestDate,
+  });
+  await expectStep(page, "/case-registration/suspect-summary");
+  await suspectSummaryPage.selectAddMoreSuspectNo();
+  await suspectSummaryPage.saveAndContinue();
+
+  const wantToAddChargesPage = new WantToAddChargesPage(page);
+  await expectStep(page, "/case-registration/want-to-add-charges");
+  await wantToAddChargesPage.selectAddChargesYes();
+  await wantToAddChargesPage.saveAndContinue();
+
+  const addChargeSuspectPage = new AddChargeSuspectPage(page);
+  const chargesSummaryPage = new ChargesSummaryPage(page);
+
+  await expectStep(page, "/case-registration/add-charge-suspect");
+  await addChargeSuspectPage.selectSuspectByIndex(0);
+  await addChargeSuspectPage.saveAndContinue();
+
+  await addCharge(page, {
+    suspectIndex: 0,
+    chargeIndex: 0,
+    offenceCode: OFFENCE_CODE,
+    dates,
+    chargedWithAdult: true,
+    victim: { mode: "new", name: victim0 },
+    hasExistingVictims: false,
+  });
+  await expectStep(page, "/case-registration/charges-summary");
+  await chargesSummaryPage.selectAddMoreChargesYes();
+  await chargesSummaryPage.saveAndContinue();
+
+  await expectStep(page, "/case-registration/add-charge-suspect");
+  await addChargeSuspectPage.selectSuspectByIndex(0);
+  await addChargeSuspectPage.saveAndContinue();
+  await addCharge(page, {
+    suspectIndex: 0,
+    chargeIndex: 1,
+    offenceCode: OFFENCE_CODE_2,
+    dates,
+    chargedWithAdult: true,
+    victim: { mode: "reuse" },
+    hasExistingVictims: true,
+  });
+  await expectStep(page, "/case-registration/charges-summary");
+  await chargesSummaryPage.selectAddMoreChargesYes();
+  await chargesSummaryPage.saveAndContinue();
+
+  await expectStep(page, "/case-registration/add-charge-suspect");
+  await addChargeSuspectPage.selectSuspectByIndex(1);
+  await addChargeSuspectPage.saveAndContinue();
+  await addCharge(page, {
+    suspectIndex: 1,
+    chargeIndex: 0,
+    offenceCode: OFFENCE_CODE,
+    dates,
+    chargedWithAdult: true,
+    victim: { mode: "new", name: victim1 },
+    hasExistingVictims: true,
+  });
+  await expectStep(page, "/case-registration/charges-summary");
+
+  const suspect0Group = page.getByTestId("charges-summary-suspect-0");
+  await expect(suspect0Group).toBeVisible();
+  await expect(suspect0Group.locator("h2")).toContainText(
+    suspect0.last.toUpperCase(),
+  );
+  await expect(suspect0Group.getByTestId("charge-0-data")).toBeVisible();
+  await expect(suspect0Group.getByTestId("charge-1-data")).toBeVisible();
+
+  const suspect1Group = page.getByTestId("charges-summary-suspect-1");
+  await expect(suspect1Group).toBeVisible();
+  await expect(suspect1Group.locator("h2")).toContainText(
+    suspect1.last.toUpperCase(),
+  );
+  await expect(suspect1Group.getByTestId("charge-0-data")).toBeVisible();
+  await expect(suspect1Group.getByTestId("charge-1-data")).toHaveCount(0);
+
+  await chargesSummaryPage.selectAddMoreChargesNo();
+  await completeFirstHearing(page, () => chargesSummaryPage.saveAndContinue());
+
+  await completeMonitoringAndAssignee(page, { preChargeChecked: false });
+
+  await verifySummaryAndSubmit(page, urn, {
+    area: AREA,
+    registeringUnit: REGISTERING_UNIT,
+    wcu: WITNESS_CARE_UNIT,
+    operationName,
+  });
+}

--- a/src/ui-spa/e2e-tests/journeys/steps.ts
+++ b/src/ui-spa/e2e-tests/journeys/steps.ts
@@ -179,6 +179,17 @@ export async function verifySummaryAndSubmit(
     `POST /api/v1/cases returned ${registerCaseResponse.status()}`,
   ).toBe(true);
 
+  // Assert on the payload, not just the status. The response body carries the
+  // created case id (not the URN), so assert it is a real, positive identifier
+  // confirming the backend actually persisted the case.
+  const body = (await registerCaseResponse.json()) as { caseId?: unknown };
+  expect(
+    typeof body.caseId === "number" &&
+      Number.isInteger(body.caseId) &&
+      body.caseId > 0,
+    `POST /api/v1/cases returned an unexpected body: ${JSON.stringify(body)}`,
+  ).toBe(true);
+
   await expectStep(page, "/case-registration/case-registration-confirmation");
   await expect(
     page.getByRole("heading", { name: "Case registered successfully" }),

--- a/src/ui-spa/e2e-tests/journeys/suspectChargeSteps.ts
+++ b/src/ui-spa/e2e-tests/journeys/suspectChargeSteps.ts
@@ -16,6 +16,7 @@ import { AddChargeVictimPage } from "../../integration-tests/pages/addChargeVict
 import { FirstHearingDetailsPage } from "../../integration-tests/pages/firstHearingDetailsPage";
 import { SuspectSummaryPage } from "../../integration-tests/pages/suspectSummaryPage";
 import { WantToAddChargesPage } from "../../integration-tests/pages/wantToAddChargesPage";
+import { formatNameUtil } from "../../src/common/utils/formatNameUtil";
 import { expectStep } from "../utils/expectStep";
 import { type UrnParts } from "../utils/generateUrn";
 import { startAtHomePage, enterAreasAndCaseDetails } from "./steps";
@@ -154,7 +155,9 @@ export interface AddChargeOptions {
   offenceCode: string;
   dates: { from: Date; to: Date };
   chargedWithAdult: boolean;
-  victim: { mode: "new"; name: PersonName } | { mode: "reuse" };
+  victim:
+    | { mode: "new"; name: PersonName }
+    | { mode: "reuse"; expectVictim: PersonName };
   hasExistingVictims: boolean;
 }
 
@@ -188,6 +191,12 @@ export async function addCharge(
   const addChargeVictimPage = new AddChargeVictimPage(page);
   await expectStep(page, `${base}/add-charge-victim`);
   if (opts.victim.mode === "reuse") {
+    await addChargeVictimPage.verifyFirstExistingVictim(
+      formatNameUtil(
+        opts.victim.expectVictim.first,
+        opts.victim.expectVictim.last,
+      ),
+    );
     await addChargeVictimPage.selectFirstExistingVictim();
   } else {
     if (opts.hasExistingVictims) {

--- a/src/ui-spa/e2e-tests/journeys/suspectChargeSteps.ts
+++ b/src/ui-spa/e2e-tests/journeys/suspectChargeSteps.ts
@@ -1,0 +1,230 @@
+import { expect, type Page } from "@playwright/test";
+import { faker } from "@faker-js/faker";
+import { AddSuspectPage } from "../../integration-tests/pages/addSuspectPage";
+import { SuspectDOBPage } from "../../integration-tests/pages/suspectDOBPage";
+import { SuspectGenderPage } from "../../integration-tests/pages/suspectGenderPage";
+import { SuspectDisabilityPage } from "../../integration-tests/pages/suspectDisabilityPage";
+import { SuspectReligionPage } from "../../integration-tests/pages/suspectReligionPage";
+import { SuspectEthnicityPage } from "../../integration-tests/pages/suspectEthnicityPage";
+import { SuspectAliasesPage } from "../../integration-tests/pages/suspectAddAliases";
+import { SuspectAliasesSummaryPage } from "../../integration-tests/pages/suspectAliasesSummary";
+import { SuspectASNPage } from "../../integration-tests/pages/suspectASNPage";
+import { SuspectOffenderTypesPage } from "../../integration-tests/pages/suspectOffenderTypesPage";
+import { ChargesOffenceSearchPagePage } from "../../integration-tests/pages/chargesOffenceSearchPage";
+import { AddChargeDetailsPage } from "../../integration-tests/pages/addChargeDetailsPage";
+import { AddChargeVictimPage } from "../../integration-tests/pages/addChargeVictimPage";
+import { FirstHearingDetailsPage } from "../../integration-tests/pages/firstHearingDetailsPage";
+import { SuspectSummaryPage } from "../../integration-tests/pages/suspectSummaryPage";
+import { WantToAddChargesPage } from "../../integration-tests/pages/wantToAddChargesPage";
+import { expectStep } from "../utils/expectStep";
+import { type UrnParts } from "../utils/generateUrn";
+import { startAtHomePage, enterAreasAndCaseDetails } from "./steps";
+
+export interface PersonName {
+  first: string;
+  last: string;
+}
+
+export const isoDate = (d: Date): string => d.toISOString().split("T")[0];
+
+const alpha = (value: string): string => value.replace(/[^A-Za-z]/g, "");
+
+export const personName = (): PersonName => ({
+  first: alpha(faker.person.firstName()),
+  last: alpha(faker.person.lastName()),
+});
+
+export function chargeDates(): {
+  offence: { from: Date; to: Date };
+  arrestDate: Date;
+} {
+  const from = new Date();
+  from.setMonth(from.getMonth() - 1);
+  const to = new Date(from);
+  to.setDate(to.getDate() + 1);
+  const arrestDate = new Date();
+  arrestDate.setDate(arrestDate.getDate() - 14);
+  return { offence: { from, to }, arrestDate };
+}
+
+export async function startSingleSuspectUpToCharges(
+  page: Page,
+  opts: { operationName: string; urn: UrnParts; arrestDate: Date },
+): Promise<void> {
+  await startAtHomePage(page, {
+    operationName: opts.operationName,
+    hasSuspect: true,
+  });
+  await enterAreasAndCaseDetails(page, opts.urn);
+
+  await addPersonSuspectWithAllDetails(page, 0, {
+    name: personName(),
+    alias: personName(),
+    arrestDate: opts.arrestDate,
+  });
+
+  const suspectSummaryPage = new SuspectSummaryPage(page);
+  await expectStep(page, "/case-registration/suspect-summary");
+  await suspectSummaryPage.selectAddMoreSuspectNo();
+  await suspectSummaryPage.saveAndContinue();
+
+  const wantToAddChargesPage = new WantToAddChargesPage(page);
+  await expectStep(page, "/case-registration/want-to-add-charges");
+  await wantToAddChargesPage.selectAddChargesYes();
+  await wantToAddChargesPage.saveAndContinue();
+}
+
+export async function addPersonSuspectWithAllDetails(
+  page: Page,
+  suspectIndex: number,
+  opts: { name: PersonName; alias: PersonName; arrestDate: Date },
+): Promise<void> {
+  const base = `/case-registration/suspect-${suspectIndex}`;
+
+  const addSuspectPage = new AddSuspectPage(page);
+  await expectStep(page, `${base}/add-suspect`);
+  await addSuspectPage.addPersonSuspect();
+  await addSuspectPage.addSuspectFirstName(opts.name.first);
+  await addSuspectPage.addSuspectLastName(opts.name.last);
+  await addSuspectPage.selectAdditionalDetailsDOB(true);
+  await addSuspectPage.selectAdditionalDetailsGender(true);
+  await addSuspectPage.selectAdditionalDetailsDisability(true);
+  await addSuspectPage.selectAdditionalDetailsReligion(true);
+  await addSuspectPage.selectAdditionalDetailsEthnicity(true);
+  await addSuspectPage.selectAdditionalDetailsASN(true);
+  await addSuspectPage.selectAdditionalDetailsAlias(true);
+  await addSuspectPage.selectAdditionalDetailsOffenderType(true);
+  await addSuspectPage.saveAndContinue();
+
+  const suspectDOBPage = new SuspectDOBPage(page);
+  await expectStep(page, `${base}/suspect-dob`);
+  const dob = new Date();
+  dob.setFullYear(dob.getFullYear() - 15);
+  await suspectDOBPage.addDOBDay(String(dob.getDate()));
+  await suspectDOBPage.addDOBMonth(String(dob.getMonth() + 1));
+  await suspectDOBPage.addDOBYear(String(dob.getFullYear()));
+  await suspectDOBPage.saveAndContinue();
+
+  const suspectGenderPage = new SuspectGenderPage(page);
+  await expectStep(page, `${base}/suspect-gender`);
+  await suspectGenderPage.selectGenderMale();
+  await suspectGenderPage.saveAndContinue();
+
+  const suspectDisabilityPage = new SuspectDisabilityPage(page);
+  await expectStep(page, `${base}/suspect-disability`);
+  await suspectDisabilityPage.selectDisabilityYes();
+  await suspectDisabilityPage.saveAndContinue();
+
+  const suspectReligionPage = new SuspectReligionPage(page);
+  await expectStep(page, `${base}/suspect-religion`);
+  await suspectReligionPage.selectFirstReligion();
+  await suspectReligionPage.saveAndContinue();
+
+  const suspectEthnicityPage = new SuspectEthnicityPage(page);
+  await expectStep(page, `${base}/suspect-ethnicity`);
+  await suspectEthnicityPage.selectFirstEthnicity();
+  await suspectEthnicityPage.saveAndContinue();
+
+  const suspectAliasesPage = new SuspectAliasesPage(page);
+  await expectStep(page, `${base}/suspect-add-aliases`);
+  await suspectAliasesPage.addFirstName(opts.alias.first);
+  await suspectAliasesPage.addLastName(opts.alias.last);
+  await suspectAliasesPage.saveAndContinue();
+
+  const suspectAliasesSummaryPage = new SuspectAliasesSummaryPage(page);
+  await expectStep(page, `${base}/suspect-aliases-summary`);
+  await suspectAliasesSummaryPage.selectAddMoreAliasesNo();
+  await suspectAliasesSummaryPage.saveAndContinue();
+
+  const suspectASNPage = new SuspectASNPage(page);
+  await expectStep(page, `${base}/suspect-asn`);
+  await suspectASNPage.addASNText("123456");
+  await suspectASNPage.saveAndContinue();
+
+  const suspectOffenderTypesPage = new SuspectOffenderTypesPage(page);
+  await expectStep(page, `${base}/suspect-offender`);
+  await suspectOffenderTypesPage.selectOffenderTypePYO();
+  await suspectOffenderTypesPage.addArrestDate(isoDate(opts.arrestDate));
+  await suspectOffenderTypesPage.saveAndContinue();
+}
+
+export interface AddChargeOptions {
+  suspectIndex: number;
+  chargeIndex: number;
+  offenceCode: string;
+  dates: { from: Date; to: Date };
+  chargedWithAdult: boolean;
+  victim: { mode: "new"; name: PersonName } | { mode: "reuse" };
+  hasExistingVictims: boolean;
+}
+
+export async function addCharge(
+  page: Page,
+  opts: AddChargeOptions,
+): Promise<void> {
+  const base = `/case-registration/suspect-${opts.suspectIndex}/charge-${opts.chargeIndex}`;
+
+  const offenceSearchPage = new ChargesOffenceSearchPagePage(page);
+  await expectStep(page, `${base}/charges-offence-search`);
+  await offenceSearchPage.addOffenceSearchText(opts.offenceCode);
+  await offenceSearchPage.searchOffence();
+  await expect(
+    page.getByTestId("offence-search-results-wrapper"),
+    `no offence result for ${opts.offenceCode}`,
+  ).toBeVisible({ timeout: 30_000 });
+  await offenceSearchPage.addOffence(0);
+
+  const addChargeDetailsPage = new AddChargeDetailsPage(page);
+  await expectStep(page, `${base}/add-charge-details`);
+  await addChargeDetailsPage.clickDateRange();
+  await addChargeDetailsPage.fillOffenceFromDate(isoDate(opts.dates.from));
+  await addChargeDetailsPage.fillOffenceToDate(isoDate(opts.dates.to));
+  await addChargeDetailsPage.selectAddVictimYes();
+  if (opts.chargedWithAdult) {
+    await addChargeDetailsPage.selectChargedWithAdultYes();
+  }
+  await addChargeDetailsPage.saveAndContinue();
+
+  const addChargeVictimPage = new AddChargeVictimPage(page);
+  await expectStep(page, `${base}/add-charge-victim`);
+  if (opts.victim.mode === "reuse") {
+    await addChargeVictimPage.selectFirstExistingVictim();
+  } else {
+    if (opts.hasExistingVictims) {
+      await addChargeVictimPage.selectVictimByName("Add new victim");
+    }
+    await addChargeVictimPage.fillVictimFirstName(opts.victim.name.first);
+    await addChargeVictimPage.fillVictimLastName(opts.victim.name.last);
+    await addChargeVictimPage.selectVictimIsVulnerable(true);
+    await addChargeVictimPage.selectVictimIsIntimidated(true);
+    await addChargeVictimPage.selectVictimIsWitness(true);
+  }
+  await addChargeVictimPage.saveAndContinue();
+}
+
+export async function completeFirstHearing(
+  page: Page,
+  navigateToFirstHearing: () => Promise<void>,
+): Promise<void> {
+  const courtsResponse = page.waitForResponse(
+    (r) => /\/api\/v1\/courts\//.test(r.url()) && r.ok(),
+    { timeout: 30_000 },
+  );
+  await navigateToFirstHearing();
+
+  const firstHearingDetailsPage = new FirstHearingDetailsPage(page);
+  await expectStep(page, "/case-registration/first-hearing");
+  const courts = (await (await courtsResponse).json()) as {
+    description: string;
+  }[];
+  const courtName = courts[0]?.description;
+  if (!courtName) {
+    throw new Error("no courts returned for the registering unit");
+  }
+  const hearingDate = new Date();
+  hearingDate.setDate(hearingDate.getDate() + 14);
+  await firstHearingDetailsPage.selectAddFirstHearingDetailsYes();
+  await firstHearingDetailsPage.enterFirstHearingCourtLocation(courtName);
+  await firstHearingDetailsPage.addFirstHearingDate(isoDate(hearingDate));
+  await firstHearingDetailsPage.saveAndContinue();
+}

--- a/src/ui-spa/e2e-tests/long-path-duplicate-victim.spec.ts
+++ b/src/ui-spa/e2e-tests/long-path-duplicate-victim.spec.ts
@@ -1,0 +1,13 @@
+import { test } from "@playwright/test";
+import { completeLongPathDuplicateVictim } from "./journeys/longPathDuplicateVictim";
+
+const OPERATION_NAME = process.env.E2E_OPERATION_NAME ?? "thunderstruck";
+
+test("Scenario 7: long path, duplicate victim confirmation, submits to /api/v1/cases", async ({
+  page,
+}) => {
+  test.setTimeout(180_000);
+  await completeLongPathDuplicateVictim(page, {
+    operationName: OPERATION_NAME,
+  });
+});

--- a/src/ui-spa/e2e-tests/long-path-multi-suspect-charge.spec.ts
+++ b/src/ui-spa/e2e-tests/long-path-multi-suspect-charge.spec.ts
@@ -1,0 +1,13 @@
+import { test } from "@playwright/test";
+import { completeLongPathMultiSuspectCharge } from "./journeys/longPathMultiSuspectCharge";
+
+const OPERATION_NAME = process.env.E2E_OPERATION_NAME ?? "thunderstruck";
+
+test("Scenario 6: long path, multiple suspects and charges with victim reuse, submits to /api/v1/cases", async ({
+  page,
+}) => {
+  test.setTimeout(180_000);
+  await completeLongPathMultiSuspectCharge(page, {
+    operationName: OPERATION_NAME,
+  });
+});

--- a/src/ui-spa/integration-tests/pages/addChargeSuspectPage.ts
+++ b/src/ui-spa/integration-tests/pages/addChargeSuspectPage.ts
@@ -43,6 +43,9 @@ export class AddChargeSuspectPage {
   async selectSuspectByName(name: string) {
     await this.page.getByLabel(name).check();
   }
+  async selectSuspectByIndex(index: number) {
+    await this.page.locator(`#suspect-radio-${index}`).check();
+  }
   async unSelectSuspectByName(name: string) {
     await this.page.getByLabel(name).uncheck();
   }

--- a/src/ui-spa/integration-tests/pages/addChargeVictimPage.ts
+++ b/src/ui-spa/integration-tests/pages/addChargeVictimPage.ts
@@ -170,6 +170,9 @@ export class AddChargeVictimPage {
   async selectVictimByName(name: string) {
     await this.page.getByLabel(name).check();
   }
+  async selectFirstExistingVictim() {
+    await this.page.locator("#add-victim-radio-0").check();
+  }
   async unSelectVictimByName(name: string) {
     await this.page.getByLabel(name).uncheck();
   }

--- a/src/ui-spa/integration-tests/pages/addChargeVictimPage.ts
+++ b/src/ui-spa/integration-tests/pages/addChargeVictimPage.ts
@@ -173,6 +173,13 @@ export class AddChargeVictimPage {
   async selectFirstExistingVictim() {
     await this.page.locator("#add-victim-radio-0").check();
   }
+  async verifyFirstExistingVictim(expectedLabel: string) {
+    // Assert the first existing-victim radio really is the victim we expect to
+    // reuse, so the "reuse" path is tied to identity and not just to ordering.
+    const reusedVictim = this.page.getByLabel(expectedLabel);
+    await expect(reusedVictim).toBeVisible();
+    await expect(reusedVictim).toHaveAttribute("id", "add-victim-radio-0");
+  }
   async unSelectVictimByName(name: string) {
     await this.page.getByLabel(name).uncheck();
   }

--- a/src/ui-spa/integration-tests/pages/chargesVictimDuplicateConfirmation.ts
+++ b/src/ui-spa/integration-tests/pages/chargesVictimDuplicateConfirmation.ts
@@ -1,0 +1,42 @@
+import { type Page, expect } from "@playwright/test";
+
+export class ChargesVictimDuplicateConfirmationPage {
+  private readonly page: Page;
+
+  constructor(page: Page) {
+    this.page = page;
+  }
+
+  async verifyUrl() {
+    await expect(this.page).toHaveURL(
+      "http://localhost:5173/case-registration/charges-victim-duplicate-confirmation",
+    );
+  }
+
+  async verifyPageElements() {
+    await expect(this.page.locator("h1")).toHaveText("Check the victim name");
+    await expect(
+      this.page.getByText("has already been added", { exact: false }),
+    ).toBeVisible();
+    await expect(
+      this.page.getByRole("button", { name: "Save and continue" }),
+    ).toBeVisible();
+    await expect(this.page.getByRole("link", { name: "Cancel" })).toBeVisible();
+  }
+
+  async verifyBackLink(url: string) {
+    await expect(this.page.getByRole("link", { name: "Back" })).toBeVisible();
+    await expect(this.page.getByRole("link", { name: "Back" })).toHaveAttribute(
+      "href",
+      url,
+    );
+  }
+
+  async saveAndContinue() {
+    await this.page.getByRole("button", { name: "Save and continue" }).click();
+  }
+
+  async cancel() {
+    await this.page.getByRole("link", { name: "Cancel" }).click();
+  }
+}


### PR DESCRIPTION
adding scenarios for longpath duplicate victim and multisuspect

<img width="1320" height="800" alt="Capture15061" src="https://github.com/user-attachments/assets/bf430ab9-ad73-466c-bead-98ed74fb5a3b" />
<img width="1040" height="407" alt="Capture1506" src="https://github.com/user-attachments/assets/dd635bb0-824f-4916-be4d-bf8ece01d91d" />
