### PR TITLE
FCT2- 17955 and FCT2-179566 Long path with suspects no charges and remove all suspects

### DIFF
--- a/src/ui-spa/e2e-tests/journeys/longPathRemoveAllSuspects.ts
+++ b/src/ui-spa/e2e-tests/journeys/longPathRemoveAllSuspects.ts
@@ -1,0 +1,89 @@
+import { type Page } from "@playwright/test";
+import { SuspectSummaryPage } from "../../integration-tests/pages/suspectSummaryPage";
+import { WantToAddChargesPage } from "../../integration-tests/pages/wantToAddChargesPage";
+import { CaseRegistrationSummaryPage } from "../../integration-tests/pages/caseRegistrationSummaryPage";
+import { CaseRegistrationHomePage } from "../../integration-tests/pages/caseRegistrationHomePage";
+import { RemoveAllSuspectsConfirmationPage } from "../../integration-tests/pages/removeAllSuspectsConfirmationPage";
+import { generateUniqueUrn } from "../utils/generateUrn";
+import { expectStep } from "../utils/expectStep";
+import {
+  AREA,
+  REGISTERING_UNIT,
+  WITNESS_CARE_UNIT,
+  startAtHomePage,
+  enterAreasAndCaseDetails,
+  completeMonitoringAndAssignee,
+  verifySummaryAndSubmit,
+} from "./steps";
+import {
+  addPersonSuspectWithAllDetails,
+  chargeDates,
+  personName,
+} from "./suspectChargeSteps";
+
+export interface LongPathRemoveAllSuspectsOptions {
+  // Required: once suspects are removed this becomes a no-suspect short path,
+  // which the UI only accepts alongside an operation name.
+  operationName: string;
+}
+
+export async function completeLongPathRemoveAllSuspects(
+  page: Page,
+  { operationName }: LongPathRemoveAllSuspectsOptions,
+): Promise<void> {
+  const urn = generateUniqueUrn();
+  const { arrestDate } = chargeDates();
+
+  // Enter suspect details Yes and add one suspect via the long path.
+  await startAtHomePage(page, { operationName, hasSuspect: true });
+  await enterAreasAndCaseDetails(page, urn);
+
+  await addPersonSuspectWithAllDetails(page, 0, {
+    name: personName(),
+    alias: personName(),
+    arrestDate,
+  });
+
+  const suspectSummaryPage = new SuspectSummaryPage(page);
+  await expectStep(page, "/case-registration/suspect-summary");
+  await suspectSummaryPage.selectAddMoreSuspectNo();
+  await suspectSummaryPage.saveAndContinue();
+
+  const wantToAddChargesPage = new WantToAddChargesPage(page);
+  await expectStep(page, "/case-registration/want-to-add-charges");
+  await wantToAddChargesPage.selectAddChargesNo();
+  await wantToAddChargesPage.saveAndContinue();
+
+  await completeMonitoringAndAssignee(page);
+
+  const summaryPage = new CaseRegistrationSummaryPage(page);
+  await expectStep(page, "/case-registration/case-summary");
+  await summaryPage.verifyAddNewSuspectElements(1);
+
+  // Return to the landing page via the operation-name change link.
+  await summaryPage.changeOperationNameLinkClick();
+
+  const homePage = new CaseRegistrationHomePage(page);
+  await expectStep(page, "/case-registration");
+  await homePage.addNoSuspect();
+  await homePage.saveAndContinue();
+
+  // Changing suspect details to No while a suspect exists must prompt for
+  // confirmation before anything is dropped.
+  const removeAllSuspectsPage = new RemoveAllSuspectsConfirmationPage(page);
+  await expectStep(page, "/case-registration/remove-all-suspects-confirmation");
+  await removeAllSuspectsPage.verifyPageElements();
+  await removeAllSuspectsPage.confirmDelete();
+
+  // On confirm, the suspect is dropped and the flow returns to the summary as a
+  // short-path (no-suspect) case.
+  await expectStep(page, "/case-registration/case-summary");
+  await summaryPage.verifyNoSuspectElements();
+
+  await verifySummaryAndSubmit(page, urn, {
+    area: AREA,
+    registeringUnit: REGISTERING_UNIT,
+    wcu: WITNESS_CARE_UNIT,
+    operationName,
+  });
+}

--- a/src/ui-spa/e2e-tests/journeys/longPathRemoveAllSuspects.ts
+++ b/src/ui-spa/e2e-tests/journeys/longPathRemoveAllSuspects.ts
@@ -1,6 +1,4 @@
 import { type Page } from "@playwright/test";
-import { SuspectSummaryPage } from "../../integration-tests/pages/suspectSummaryPage";
-import { WantToAddChargesPage } from "../../integration-tests/pages/wantToAddChargesPage";
 import { CaseRegistrationSummaryPage } from "../../integration-tests/pages/caseRegistrationSummaryPage";
 import { CaseRegistrationHomePage } from "../../integration-tests/pages/caseRegistrationHomePage";
 import { RemoveAllSuspectsConfirmationPage } from "../../integration-tests/pages/removeAllSuspectsConfirmationPage";
@@ -10,15 +8,12 @@ import {
   AREA,
   REGISTERING_UNIT,
   WITNESS_CARE_UNIT,
-  startAtHomePage,
-  enterAreasAndCaseDetails,
   completeMonitoringAndAssignee,
   verifySummaryAndSubmit,
 } from "./steps";
 import {
-  addPersonSuspectWithAllDetails,
   chargeDates,
-  personName,
+  startSingleSuspectUpToCharges,
 } from "./suspectChargeSteps";
 
 export interface LongPathRemoveAllSuspectsOptions {
@@ -34,25 +29,14 @@ export async function completeLongPathRemoveAllSuspects(
   const urn = generateUniqueUrn();
   const { arrestDate } = chargeDates();
 
-  // Enter suspect details Yes and add one suspect via the long path.
-  await startAtHomePage(page, { operationName, hasSuspect: true });
-  await enterAreasAndCaseDetails(page, urn);
-
-  await addPersonSuspectWithAllDetails(page, 0, {
-    name: personName(),
-    alias: personName(),
+  // Enter suspect details Yes and add one suspect via the long path, answering
+  // No to charges.
+  await startSingleSuspectUpToCharges(page, {
+    operationName,
+    urn,
     arrestDate,
+    addCharges: false,
   });
-
-  const suspectSummaryPage = new SuspectSummaryPage(page);
-  await expectStep(page, "/case-registration/suspect-summary");
-  await suspectSummaryPage.selectAddMoreSuspectNo();
-  await suspectSummaryPage.saveAndContinue();
-
-  const wantToAddChargesPage = new WantToAddChargesPage(page);
-  await expectStep(page, "/case-registration/want-to-add-charges");
-  await wantToAddChargesPage.selectAddChargesNo();
-  await wantToAddChargesPage.saveAndContinue();
 
   await completeMonitoringAndAssignee(page);
 

--- a/src/ui-spa/e2e-tests/journeys/longPathWantToAddChargesNo.ts
+++ b/src/ui-spa/e2e-tests/journeys/longPathWantToAddChargesNo.ts
@@ -1,17 +1,10 @@
 import { type Page } from "@playwright/test";
-import { SuspectSummaryPage } from "../../integration-tests/pages/suspectSummaryPage";
-import { WantToAddChargesPage } from "../../integration-tests/pages/wantToAddChargesPage";
 import { generateUniqueUrn } from "../utils/generateUrn";
 import { expectStep, expectNotStep } from "../utils/expectStep";
+import { completeAssigneeAndSubmit } from "./steps";
 import {
-  startAtHomePage,
-  enterAreasAndCaseDetails,
-  completeAssigneeAndSubmit,
-} from "./steps";
-import {
-  addPersonSuspectWithAllDetails,
   chargeDates,
-  personName,
+  startSingleSuspectUpToCharges,
 } from "./suspectChargeSteps";
 
 export interface LongPathWantToAddChargesNoOptions {
@@ -36,24 +29,12 @@ export async function completeLongPathWantToAddChargesNo(
   const urn = generateUniqueUrn();
   const { arrestDate } = chargeDates();
 
-  await startAtHomePage(page, { operationName, hasSuspect: true });
-  await enterAreasAndCaseDetails(page, urn);
-
-  await addPersonSuspectWithAllDetails(page, 0, {
-    name: personName(),
-    alias: personName(),
+  await startSingleSuspectUpToCharges(page, {
+    operationName,
+    urn,
     arrestDate,
+    addCharges: false,
   });
-
-  const suspectSummaryPage = new SuspectSummaryPage(page);
-  await expectStep(page, "/case-registration/suspect-summary");
-  await suspectSummaryPage.selectAddMoreSuspectNo();
-  await suspectSummaryPage.saveAndContinue();
-
-  const wantToAddChargesPage = new WantToAddChargesPage(page);
-  await expectStep(page, "/case-registration/want-to-add-charges");
-  await wantToAddChargesPage.selectAddChargesNo();
-  await wantToAddChargesPage.saveAndContinue();
 
   // The "No" branch lands directly on case monitoring codes, skipping the
   // entire charge sub-flow and the first hearing.

--- a/src/ui-spa/e2e-tests/journeys/longPathWantToAddChargesNo.ts
+++ b/src/ui-spa/e2e-tests/journeys/longPathWantToAddChargesNo.ts
@@ -32,11 +32,12 @@ export async function completeLongPathWantToAddChargesNo(
   // Record every page we actually land on so we can prove the charge sub-flow
   // was never entered. Checking the current URL can't show this: by the time we
   // reach case monitoring codes the charge pages are trivially "not current"
-  // regardless of whether the flow passed through them.
+  // regardless of whether the flow passed through them. Strip any trailing slash
+  // so a route emitted as ".../charges-summary/" still matches SKIPPED_STEPS.
   const visited: string[] = [];
   page.on("framenavigated", (frame) => {
     if (frame === page.mainFrame()) {
-      visited.push(new URL(frame.url()).pathname);
+      visited.push(new URL(frame.url()).pathname.replace(/\/$/, ""));
     }
   });
 

--- a/src/ui-spa/e2e-tests/journeys/longPathWantToAddChargesNo.ts
+++ b/src/ui-spa/e2e-tests/journeys/longPathWantToAddChargesNo.ts
@@ -1,0 +1,66 @@
+import { type Page } from "@playwright/test";
+import { SuspectSummaryPage } from "../../integration-tests/pages/suspectSummaryPage";
+import { WantToAddChargesPage } from "../../integration-tests/pages/wantToAddChargesPage";
+import { generateUniqueUrn } from "../utils/generateUrn";
+import { expectStep, expectNotStep } from "../utils/expectStep";
+import {
+  startAtHomePage,
+  enterAreasAndCaseDetails,
+  completeAssigneeAndSubmit,
+} from "./steps";
+import {
+  addPersonSuspectWithAllDetails,
+  chargeDates,
+  personName,
+} from "./suspectChargeSteps";
+
+export interface LongPathWantToAddChargesNoOptions {
+  operationName?: string;
+}
+
+// Pages that only belong to the "add charges" branch. Answering "No" on the
+// want-to-add-charges page must skip every one of these (and the charge-driven
+// first-hearing page) and land straight on the case monitoring codes page.
+const SKIPPED_STEPS = [
+  "/case-registration/suspect-0/charge-0/charges-offence-search",
+  "/case-registration/suspect-0/charge-0/add-charge-details",
+  "/case-registration/suspect-0/charge-0/add-charge-victim",
+  "/case-registration/charges-summary",
+  "/case-registration/first-hearing",
+];
+
+export async function completeLongPathWantToAddChargesNo(
+  page: Page,
+  { operationName }: LongPathWantToAddChargesNoOptions = {},
+): Promise<void> {
+  const urn = generateUniqueUrn();
+  const { arrestDate } = chargeDates();
+
+  await startAtHomePage(page, { operationName, hasSuspect: true });
+  await enterAreasAndCaseDetails(page, urn);
+
+  await addPersonSuspectWithAllDetails(page, 0, {
+    name: personName(),
+    alias: personName(),
+    arrestDate,
+  });
+
+  const suspectSummaryPage = new SuspectSummaryPage(page);
+  await expectStep(page, "/case-registration/suspect-summary");
+  await suspectSummaryPage.selectAddMoreSuspectNo();
+  await suspectSummaryPage.saveAndContinue();
+
+  const wantToAddChargesPage = new WantToAddChargesPage(page);
+  await expectStep(page, "/case-registration/want-to-add-charges");
+  await wantToAddChargesPage.selectAddChargesNo();
+  await wantToAddChargesPage.saveAndContinue();
+
+  // The "No" branch lands directly on case monitoring codes, skipping the
+  // entire charge sub-flow and the first hearing.
+  await expectStep(page, "/case-registration/case-monitoring-codes");
+  for (const skipped of SKIPPED_STEPS) {
+    await expectNotStep(page, skipped);
+  }
+
+  await completeAssigneeAndSubmit(page, urn, operationName);
+}

--- a/src/ui-spa/e2e-tests/journeys/longPathWantToAddChargesNo.ts
+++ b/src/ui-spa/e2e-tests/journeys/longPathWantToAddChargesNo.ts
@@ -1,6 +1,6 @@
-import { type Page } from "@playwright/test";
+import { expect, type Page } from "@playwright/test";
 import { generateUniqueUrn } from "../utils/generateUrn";
-import { expectStep, expectNotStep } from "../utils/expectStep";
+import { expectStep } from "../utils/expectStep";
 import { completeAssigneeAndSubmit } from "./steps";
 import {
   chargeDates,
@@ -29,6 +29,17 @@ export async function completeLongPathWantToAddChargesNo(
   const urn = generateUniqueUrn();
   const { arrestDate } = chargeDates();
 
+  // Record every page we actually land on so we can prove the charge sub-flow
+  // was never entered. Checking the current URL can't show this: by the time we
+  // reach case monitoring codes the charge pages are trivially "not current"
+  // regardless of whether the flow passed through them.
+  const visited: string[] = [];
+  page.on("framenavigated", (frame) => {
+    if (frame === page.mainFrame()) {
+      visited.push(new URL(frame.url()).pathname);
+    }
+  });
+
   await startSingleSuspectUpToCharges(page, {
     operationName,
     urn,
@@ -40,7 +51,10 @@ export async function completeLongPathWantToAddChargesNo(
   // entire charge sub-flow and the first hearing.
   await expectStep(page, "/case-registration/case-monitoring-codes");
   for (const skipped of SKIPPED_STEPS) {
-    await expectNotStep(page, skipped);
+    expect(
+      visited,
+      `flow should not have navigated to ${skipped}`,
+    ).not.toContain(skipped);
   }
 
   await completeAssigneeAndSubmit(page, urn, operationName);

--- a/src/ui-spa/e2e-tests/journeys/suspectChargeSteps.ts
+++ b/src/ui-spa/e2e-tests/journeys/suspectChargeSteps.ts
@@ -50,7 +50,12 @@ export function chargeDates(): {
 
 export async function startSingleSuspectUpToCharges(
   page: Page,
-  opts: { operationName: string; urn: UrnParts; arrestDate: Date },
+  opts: {
+    operationName?: string;
+    urn: UrnParts;
+    arrestDate: Date;
+    addCharges?: boolean;
+  },
 ): Promise<void> {
   await startAtHomePage(page, {
     operationName: opts.operationName,
@@ -71,7 +76,11 @@ export async function startSingleSuspectUpToCharges(
 
   const wantToAddChargesPage = new WantToAddChargesPage(page);
   await expectStep(page, "/case-registration/want-to-add-charges");
-  await wantToAddChargesPage.selectAddChargesYes();
+  if (opts.addCharges ?? true) {
+    await wantToAddChargesPage.selectAddChargesYes();
+  } else {
+    await wantToAddChargesPage.selectAddChargesNo();
+  }
   await wantToAddChargesPage.saveAndContinue();
 }
 

--- a/src/ui-spa/e2e-tests/long-path-remove-all-suspects.spec.ts
+++ b/src/ui-spa/e2e-tests/long-path-remove-all-suspects.spec.ts
@@ -1,0 +1,12 @@
+import { test } from "@playwright/test";
+import { completeLongPathRemoveAllSuspects } from "./journeys/longPathRemoveAllSuspects";
+
+const OPERATION_NAME = process.env.E2E_OPERATION_NAME ?? "thunderstruck";
+
+test("Scenario 8: long path, suspect added then suspect details changed to No, confirms removal and submits the short path to /api/v1/cases", async ({
+  page,
+}) => {
+  await completeLongPathRemoveAllSuspects(page, {
+    operationName: OPERATION_NAME,
+  });
+});

--- a/src/ui-spa/e2e-tests/long-path-want-to-add-charges-no.spec.ts
+++ b/src/ui-spa/e2e-tests/long-path-want-to-add-charges-no.spec.ts
@@ -1,0 +1,12 @@
+import { test } from "@playwright/test";
+import { completeLongPathWantToAddChargesNo } from "./journeys/longPathWantToAddChargesNo";
+
+const OPERATION_NAME = process.env.E2E_OPERATION_NAME ?? "thunderstruck";
+
+test("Scenario 5: long path, suspect added then 'add charges' answered No, skips the charge flow and submits to /api/v1/cases", async ({
+  page,
+}) => {
+  await completeLongPathWantToAddChargesNo(page, {
+    operationName: OPERATION_NAME,
+  });
+});

--- a/src/ui-spa/e2e-tests/utils/expectStep.ts
+++ b/src/ui-spa/e2e-tests/utils/expectStep.ts
@@ -11,12 +11,3 @@ export const expectStep = async (
     new RegExp(String.raw`^https?://[^/]+${escapeRegExp(pathname)}/?(\?.*)?$`),
   );
 };
-
-export const expectNotStep = async (
-  page: Page,
-  pathname: string,
-): Promise<void> => {
-  await expect(page, `expected flow to skip ${pathname}`).not.toHaveURL(
-    new RegExp(String.raw`^https?://[^/]+${escapeRegExp(pathname)}/?(\?.*)?$`),
-  );
-};

--- a/src/ui-spa/e2e-tests/utils/expectStep.ts
+++ b/src/ui-spa/e2e-tests/utils/expectStep.ts
@@ -8,7 +8,7 @@ export const expectStep = async (
   pathname: string,
 ): Promise<void> => {
   await expect(page).toHaveURL(
-    new RegExp(`^https?://[^/]+${escapeRegExp(pathname)}/?(\\?.*)?$`),
+    new RegExp(String.raw`^https?://[^/]+${escapeRegExp(pathname)}/?(\?.*)?$`),
   );
 };
 
@@ -17,6 +17,6 @@ export const expectNotStep = async (
   pathname: string,
 ): Promise<void> => {
   await expect(page, `expected flow to skip ${pathname}`).not.toHaveURL(
-    new RegExp(`^https?://[^/]+${escapeRegExp(pathname)}/?(\\?.*)?$`),
+    new RegExp(String.raw`^https?://[^/]+${escapeRegExp(pathname)}/?(\?.*)?$`),
   );
 };

--- a/src/ui-spa/e2e-tests/utils/expectStep.ts
+++ b/src/ui-spa/e2e-tests/utils/expectStep.ts
@@ -11,3 +11,12 @@ export const expectStep = async (
     new RegExp(`^https?://[^/]+${escapeRegExp(pathname)}/?(\\?.*)?$`),
   );
 };
+
+export const expectNotStep = async (
+  page: Page,
+  pathname: string,
+): Promise<void> => {
+  await expect(page, `expected flow to skip ${pathname}`).not.toHaveURL(
+    new RegExp(`^https?://[^/]+${escapeRegExp(pathname)}/?(\\?.*)?$`),
+  );
+};

--- a/src/ui-spa/integration-tests/pages/removeAllSuspectsConfirmationPage.ts
+++ b/src/ui-spa/integration-tests/pages/removeAllSuspectsConfirmationPage.ts
@@ -1,0 +1,35 @@
+import { type Page, expect } from "@playwright/test";
+
+export class RemoveAllSuspectsConfirmationPage {
+  private readonly page: Page;
+
+  constructor(page: Page) {
+    this.page = page;
+  }
+
+  async verifyUrl() {
+    await expect(this.page).toHaveURL(
+      "http://localhost:5173/case-registration/remove-all-suspects-confirmation",
+    );
+  }
+
+  async verifyPageElements() {
+    await expect(this.page.locator("h1")).toHaveText(
+      "Are you sure you want to delete the suspect details?",
+    );
+    await expect(
+      this.page.getByRole("button", { name: "Delete suspect details" }),
+    ).toBeVisible();
+    await expect(this.page.getByRole("link", { name: "Cancel" })).toBeVisible();
+  }
+
+  async confirmDelete() {
+    await this.page
+      .getByRole("button", { name: "Delete suspect details" })
+      .click();
+  }
+
+  async cancel() {
+    await this.page.getByRole("link", { name: "Cancel" }).click();
+  }
+}

--- a/src/ui-spa/integration-tests/pages/removeAllSuspectsConfirmationPage.ts
+++ b/src/ui-spa/integration-tests/pages/removeAllSuspectsConfirmationPage.ts
@@ -7,12 +7,6 @@ export class RemoveAllSuspectsConfirmationPage {
     this.page = page;
   }
 
-  async verifyUrl() {
-    await expect(this.page).toHaveURL(
-      "http://localhost:5173/case-registration/remove-all-suspects-confirmation",
-    );
-  }
-
   async verifyPageElements() {
     await expect(this.page.locator("h1")).toHaveText(
       "Are you sure you want to delete the suspect details?",
@@ -27,9 +21,5 @@ export class RemoveAllSuspectsConfirmationPage {
     await this.page
       .getByRole("button", { name: "Delete suspect details" })
       .click();
-  }
-
-  async cancel() {
-    await this.page.getByRole("link", { name: "Cancel" }).click();
   }
 }

--- a/src/ui-spa/integration-tests/pages/wantToAddChargesPage.ts
+++ b/src/ui-spa/integration-tests/pages/wantToAddChargesPage.ts
@@ -40,10 +40,17 @@ export class WantToAddChargesPage {
     ).toBeFocused();
   }
   async selectAddChargesYes() {
-    await this.page.getByLabel(/^Yes$/).check();
+    await this.selectRadioReliably(/^Yes$/);
   }
   async selectAddChargesNo() {
-    await this.page.getByLabel(/^No$/).check();
+    await this.selectRadioReliably(/^No$/);
+  }
+  private async selectRadioReliably(label: RegExp) {
+    const radio = this.page.getByLabel(label);
+    await expect(async () => {
+      await radio.check();
+      await expect(radio).toBeChecked({ timeout: 1_000 });
+    }).toPass({ timeout: 10_000 });
   }
   async verifyBackLink(url: string) {
     await expect(this.page.getByRole("link", { name: "Back" })).toBeVisible();


### PR DESCRIPTION
Adding scenarios to cover FCT2-17956 and FCT2-17955

 Note: intentional overlap between Scenario 5 and `suspectNoCharges.ts`  
  Scenario 5 (`longPathWantToAddChargesNo.ts`) covers a route similar to the
  existing `suspectNoCharges.ts` add a suspect, answer "No" to charges, submit 
  but it is deliberately kept as a separate journey, not a duplicate:

  - `suspectNoCharges.ts` adds a minimal suspect (name only) and is the
    short-path baseline for the No-charges decision.
  - Scenario 5 adds a suspect with *full* details (DOB, gender, disability,
    religion, ethnicity, aliases, ASN, offender type, arrest date) via the long
    path, and additionally asserts the charge sub-flow is never entered


<img width="782" height="469" alt="evi220602" src="https://github.com/user-attachments/assets/81c4564b-b792-46b9-9cdc-8b3fce17da4c" />
<img width="1012" height="782" alt="evi220601" src="https://github.com/user-attachments/assets/26b7fb74-ab87-4f15-be7a-b79127fe5c0d" />



