### PR TITLE
FCT2-17953: add e2e scenario for suspect and charge removal

### DIFF
--- a/src/ui-spa/e2e-tests/journeys/longPathSuspectChargeRemoval.ts
+++ b/src/ui-spa/e2e-tests/journeys/longPathSuspectChargeRemoval.ts
@@ -1,0 +1,152 @@
+import { expect, type Page } from "@playwright/test";
+import { SuspectSummaryPage } from "../../integration-tests/pages/suspectSummaryPage";
+import { SuspectRemoveConfirmationPage } from "../../integration-tests/pages/suspectRemoveConfirmationPage";
+import { WantToAddChargesPage } from "../../integration-tests/pages/wantToAddChargesPage";
+import { ChargesSummaryPage } from "../pages/chargesSummaryPage";
+import { ChargeRemoveConfirmationPage } from "../pages/chargeRemoveConfirmationPage";
+import { generateUniqueUrn } from "../utils/generateUrn";
+import { expectStep } from "../utils/expectStep";
+import { formatNameUtil } from "../../src/common/utils/formatNameUtil";
+import {
+  startAtHomePage,
+  enterAreasAndCaseDetails,
+  completeAssigneeAndSubmit,
+} from "./steps";
+import {
+  personName,
+  chargeDates,
+  addPersonSuspectWithAllDetails,
+  addCharge,
+} from "./suspectChargeSteps";
+
+const OFFENCE_CODE = process.env.E2E_OFFENCE_CODE ?? "TH68040";
+const SUSPECT_SUMMARY_STEP = "/case-registration/suspect-summary";
+const SUSPECT_REMOVE_CONFIRMATION_STEP =
+  "/case-registration/suspect-remove-confirmation";
+const CHARGES_SUMMARY_STEP = "/case-registration/charges-summary";
+
+export interface LongPathSuspectChargeRemovalOptions {
+  operationName: string;
+}
+
+export async function completeLongPathSuspectChargeRemoval(
+  page: Page,
+  { operationName }: LongPathSuspectChargeRemovalOptions,
+): Promise<void> {
+  const urn = generateUniqueUrn();
+  const suspect0 = personName();
+  const suspect1 = personName();
+  const victim = personName();
+  const { offence: dates, arrestDate } = chargeDates();
+
+  const suspect0Name = formatNameUtil(suspect0.first, suspect0.last);
+  const suspect1Name = formatNameUtil(suspect1.first, suspect1.last);
+
+  // Record every page we land on so we can prove the first-hearing step is never
+  // entered. Once the charge is removed and we reach case monitoring codes the
+  // first-hearing page is trivially "not current" regardless of whether the flow
+  // passed through it, so a current-URL check proves nothing. Strip any trailing
+  // slash so a route emitted as ".../first-hearing/" still matches.
+  const visited: string[] = [];
+  page.on("framenavigated", (frame) => {
+    if (frame === page.mainFrame()) {
+      visited.push(new URL(frame.url()).pathname.replace(/\/$/, ""));
+    }
+  });
+
+  await startAtHomePage(page, { operationName, hasSuspect: true });
+  await enterAreasAndCaseDetails(page, urn);
+
+  const suspectSummaryPage = new SuspectSummaryPage(page);
+
+  // Add the first suspect, then choose to add another.
+  await addPersonSuspectWithAllDetails(page, 0, {
+    name: suspect0,
+    alias: personName(),
+    arrestDate,
+  });
+  await expectStep(page, SUSPECT_SUMMARY_STEP);
+  await suspectSummaryPage.selectAddMoreSuspectYes();
+  await suspectSummaryPage.saveAndContinue();
+
+  // Add the second suspect.
+  await addPersonSuspectWithAllDetails(page, 1, {
+    name: suspect1,
+    alias: personName(),
+    arrestDate,
+  });
+  await expectStep(page, SUSPECT_SUMMARY_STEP);
+  await suspectSummaryPage.verifySuspectSummaryRows([
+    suspect0Name,
+    suspect1Name,
+  ]);
+
+  const suspectRemoveConfirmationPage = new SuspectRemoveConfirmationPage(page);
+
+  // Cancel flow: start removing the second suspect, then back out via Cancel.
+  // Both suspects must survive.
+  await suspectSummaryPage.removeSuspect(1);
+  await expectStep(page, SUSPECT_REMOVE_CONFIRMATION_STEP);
+  await suspectRemoveConfirmationPage.verifyPageElements(suspect1Name);
+  await suspectRemoveConfirmationPage.cancel();
+  await expectStep(page, SUSPECT_SUMMARY_STEP);
+  await suspectSummaryPage.verifySuspectSummaryRows([
+    suspect0Name,
+    suspect1Name,
+  ]);
+
+  // Confirm flow: remove the second suspect for real, leaving only the first.
+  await suspectSummaryPage.removeSuspect(1);
+  await expectStep(page, SUSPECT_REMOVE_CONFIRMATION_STEP);
+  await suspectRemoveConfirmationPage.saveAndContinue();
+  await expectStep(page, SUSPECT_SUMMARY_STEP);
+  await suspectSummaryPage.verifySuspectSummaryRows([suspect0Name]);
+
+  // One suspect remains; continue to the charges branch.
+  await suspectSummaryPage.selectAddMoreSuspectNo();
+  await suspectSummaryPage.saveAndContinue();
+
+  const wantToAddChargesPage = new WantToAddChargesPage(page);
+  await expectStep(page, "/case-registration/want-to-add-charges");
+  await wantToAddChargesPage.selectAddChargesYes();
+  await wantToAddChargesPage.saveAndContinue();
+
+  // With a single suspect the add-charge-suspect step is skipped and the flow
+  // goes straight into the charge sub-flow for suspect 0.
+  await addCharge(page, {
+    suspectIndex: 0,
+    chargeIndex: 0,
+    offenceCode: OFFENCE_CODE,
+    dates,
+    chargedWithAdult: true,
+    victim: { mode: "new", name: victim },
+    hasExistingVictims: false,
+  });
+
+  const chargesSummaryPage = new ChargesSummaryPage(page);
+  const chargeRemoveConfirmationPage = new ChargeRemoveConfirmationPage(page);
+  await expectStep(page, CHARGES_SUMMARY_STEP);
+  await expect(
+    page.getByTestId("charges-summary-suspect-0").getByTestId("charge-0-data"),
+  ).toBeVisible();
+
+  // Remove the only charge via the charge-remove-confirmation page.
+  await chargesSummaryPage.removeSuspectCharge(0, 0);
+  await expectStep(page, "/case-registration/charge-remove-confirmation");
+  await chargeRemoveConfirmationPage.verifyPageElements();
+  await chargeRemoveConfirmationPage.saveAndContinue();
+  await expectStep(page, CHARGES_SUMMARY_STEP);
+  await chargesSummaryPage.verifyNoCharges();
+
+  // No charges remain: answering No skips the first hearing and lands directly
+  // on case monitoring codes.
+  await chargesSummaryPage.selectAddMoreChargesNo();
+  await chargesSummaryPage.saveAndContinue();
+  await expectStep(page, "/case-registration/case-monitoring-codes");
+  expect(
+    visited,
+    "flow should not have navigated to the first hearing page",
+  ).not.toContain("/case-registration/first-hearing");
+
+  await completeAssigneeAndSubmit(page, urn, operationName);
+}

--- a/src/ui-spa/e2e-tests/journeys/longPathSuspectChargeRemoval.ts
+++ b/src/ui-spa/e2e-tests/journeys/longPathSuspectChargeRemoval.ts
@@ -143,6 +143,12 @@ export async function completeLongPathSuspectChargeRemoval(
   await chargesSummaryPage.selectAddMoreChargesNo();
   await chargesSummaryPage.saveAndContinue();
   await expectStep(page, "/case-registration/case-monitoring-codes");
+  // Confirm the tracker recorded the step we just landed on, so the negative
+  // assertion below fails loud if framenavigated ever stops firing.
+  expect(
+    visited,
+    "navigation tracker did not record the monitoring-codes step",
+  ).toContain("/case-registration/case-monitoring-codes");
   expect(
     visited,
     "flow should not have navigated to the first hearing page",

--- a/src/ui-spa/e2e-tests/long-path-suspect-charge-removal.spec.ts
+++ b/src/ui-spa/e2e-tests/long-path-suspect-charge-removal.spec.ts
@@ -1,0 +1,13 @@
+import { test } from "@playwright/test";
+import { completeLongPathSuspectChargeRemoval } from "./journeys/longPathSuspectChargeRemoval";
+
+const OPERATION_NAME = process.env.E2E_OPERATION_NAME ?? "thunderstruck";
+
+test("Scenario 9: long path, remove a second suspect (cancel then confirm) and remove a charge, submits the remaining suspect with no charges to /api/v1/cases", async ({
+  page,
+}) => {
+  test.setTimeout(180_000);
+  await completeLongPathSuspectChargeRemoval(page, {
+    operationName: OPERATION_NAME,
+  });
+});

--- a/src/ui-spa/e2e-tests/pages/chargeRemoveConfirmationPage.ts
+++ b/src/ui-spa/e2e-tests/pages/chargeRemoveConfirmationPage.ts
@@ -1,0 +1,39 @@
+import { type Page, expect } from "@playwright/test";
+
+export class ChargeRemoveConfirmationPage {
+  private readonly page: Page;
+
+  constructor(page: Page) {
+    this.page = page;
+  }
+
+  private saveAndContinueButton() {
+    return this.page.getByRole("button", { name: "Save and continue" });
+  }
+
+  async verifyPageElements(
+    backRoute: string = "/case-registration/charges-summary",
+  ) {
+    await expect(this.page).toHaveTitle(
+      /Charge Remove Confirmation - Register A Case/,
+    );
+    await expect(this.page.locator("h1")).toHaveText(
+      "Are you sure you want to remove this charge?",
+    );
+    const paragraphs = this.page.getByTestId("main-content").locator("p");
+    await expect(paragraphs.nth(0)).toHaveText(
+      "This will permanently remove all the details you've entered.",
+    );
+    await expect(paragraphs.nth(1)).toHaveText(
+      "You will not be able to restore them.",
+    );
+    await expect(this.saveAndContinueButton()).toBeVisible();
+    await expect(
+      this.page.getByRole("link", { name: "cancel" }),
+    ).toHaveAttribute("href", backRoute);
+  }
+
+  async saveAndContinue() {
+    await this.saveAndContinueButton().click();
+  }
+}

--- a/src/ui-spa/e2e-tests/pages/chargesSummaryPage.ts
+++ b/src/ui-spa/e2e-tests/pages/chargesSummaryPage.ts
@@ -1,10 +1,8 @@
 import { type Page, expect } from "@playwright/test";
 import { ChargesSummaryPage as IntegrationChargesSummaryPage } from "../../integration-tests/pages/chargesSummaryPage";
 
-// Reuses the integration page object (identical selectors) and only overrides
-// the no-charges assertion: against the real backend the heading renders the
-// singular "You have added 0 charge" for zero charges, whereas the MSW-backed
-// integration suite expects the plural form.
+// Overrides only the no-charges assertion: the heading pluralizes on
+// chargesCount > 1, so zero renders the singular "You have added 0 charge".
 export class ChargesSummaryPage extends IntegrationChargesSummaryPage {
   private readonly currentPage: Page;
 

--- a/src/ui-spa/e2e-tests/pages/chargesSummaryPage.ts
+++ b/src/ui-spa/e2e-tests/pages/chargesSummaryPage.ts
@@ -1,0 +1,33 @@
+import { type Page, expect } from "@playwright/test";
+import { ChargesSummaryPage as IntegrationChargesSummaryPage } from "../../integration-tests/pages/chargesSummaryPage";
+
+// Reuses the integration page object (identical selectors) and only overrides
+// the no-charges assertion: against the real backend the heading renders the
+// singular "You have added 0 charge" for zero charges, whereas the MSW-backed
+// integration suite expects the plural form.
+export class ChargesSummaryPage extends IntegrationChargesSummaryPage {
+  private readonly currentPage: Page;
+
+  constructor(page: Page) {
+    super(page);
+    this.currentPage = page;
+  }
+
+  async verifyNoCharges() {
+    await expect(
+      this.currentPage.getByTestId("suspect-aliases-summary-list"),
+    ).toHaveCount(0);
+    await expect(this.currentPage.locator("h1")).toHaveText(
+      "You have added 0 charge",
+    );
+    await expect(this.currentPage.locator("legend").nth(0)).toHaveText(
+      "Do you need to add a charge for any suspect?",
+    );
+    const labels = this.currentPage.locator("label");
+    await expect(labels.nth(0)).toHaveText("Yes");
+    await expect(labels.nth(1)).toHaveText("No");
+    await expect(
+      this.currentPage.getByTestId("charges-summary"),
+    ).not.toBeVisible();
+  }
+}


### PR DESCRIPTION
Scenario 9 (long path): add two suspects, remove the second via the suspect-remove-confirmation page exercising both cancel and confirm flows, add a charge then remove it via the charge-remove-confirmation page, and submit the remaining suspect with no charges to POST /api/v1/cases.

<img width="774" height="424" alt="25062026-1" src="https://github.com/user-attachments/assets/2749a699-10df-459a-97d3-1b9605d47ec2" />
