### PR TITLE
enable deployment to Prod

### DIFF
--- a/devops-pipelines/backend/backend-build-and-deploy.yml
+++ b/devops-pipelines/backend/backend-build-and-deploy.yml
@@ -66,15 +66,15 @@ stages:
       slotName: 'stg'
       buildArtifact: $(buildArtifact)
 
-  # - template: ../templates/backend-deploy-stages.yml
-  #   parameters:
-  #     buildStageName: 'Build'
-  #     environment: 'prod'
-  #     requireValidation: true
-  #     notifyUsers: $(prodNotifyUsers)
-  #     approvers: $(prodApprovers)
-  #     agentPool: 'CMRC Prod Pool'
-  #     azureSubscription: 'Azure Pipeline: CMRC - Prod'
-  #     deployToSlot: true
-  #     slotName: 'stg'
-  #     buildArtifact: $(buildArtifact)
+  - template: ../templates/backend-deploy-stages.yml
+    parameters:
+      buildStageName: 'Build'
+      environment: 'prod'
+      requireValidation: true
+      notifyUsers: $(prodNotifyUsers)
+      approvers: $(prodApprovers)
+      agentPool: 'CMRC Prod Pool'
+      azureSubscription: 'Azure Pipeline: CMRC - Prod'
+      deployToSlot: true
+      slotName: 'stg'
+      buildArtifact: $(buildArtifact)

--- a/devops-pipelines/templates/fa-config-steps.yml
+++ b/devops-pipelines/templates/fa-config-steps.yml
@@ -67,5 +67,10 @@ steps:
             "name": "WEBSITE_USE_PLACEHOLDER_DOTNETISOLATED",
             "value": "1",
             "slotSetting": false
+          },
+          {
+            "name": "AZURE_FUNCTIONS_ENVIRONMENT",
+            "value": "$(AzureFunctionsEnvironment)"
+            "slotSetting": false
           }
         ]

--- a/devops-pipelines/templates/variables/fa-config-dev.yml
+++ b/devops-pipelines/templates/variables/fa-config-dev.yml
@@ -1,6 +1,5 @@
-# # Add any non-sensitive environment-specific app settings below (e.g. feature flags):
+# Add any non-sensitive environment-specific app settings below (e.g. feature flags):
 
 variables:
-
-- name: placeholder-flag
-  value: false
+- name: AzureFunctionsEnvironment
+  value: "PreProd"

--- a/devops-pipelines/templates/variables/fa-config-prod.yml
+++ b/devops-pipelines/templates/variables/fa-config-prod.yml
@@ -1,0 +1,5 @@
+# # Add any non-sensitive environment-specific app settings below (e.g. feature flags):
+
+variables:
+- name: placeholder-flag
+  value: false

--- a/devops-pipelines/templates/variables/fa-config-prod.yml
+++ b/devops-pipelines/templates/variables/fa-config-prod.yml
@@ -1,5 +1,5 @@
-# # Add any non-sensitive environment-specific app settings below (e.g. feature flags):
+# Add any non-sensitive environment-specific app settings below (e.g. feature flags):
 
 variables:
-- name: placeholder-flag
-  value: false
+- name: AzureFunctionsEnvironment
+  value: "Production"

--- a/devops-pipelines/templates/variables/fa-config-staging.yml
+++ b/devops-pipelines/templates/variables/fa-config-staging.yml
@@ -1,5 +1,5 @@
-# # Add any non-sensitive environment-specific app settings below (e.g. feature flags):
+# Add any non-sensitive environment-specific app settings below (e.g. feature flags):
 
 variables:
-- name: placeholder-flag
-  value: false
+- name: AzureFunctionsEnvironment
+  value: "PreProd"

--- a/devops-pipelines/ui/ui-build-and-deploy.yml
+++ b/devops-pipelines/ui/ui-build-and-deploy.yml
@@ -21,18 +21,18 @@ stages:
     parameters:
       environment: 'staging'
       requireValidation: true
-      notifyUsers: $(notifyUsers)
-      approvers: $(approvers)
+      notifyUsers: $(preprodNotifyUsers)
+      approvers: $(preprodApprovers)
       deployToSlot: true
       slotName: 'stg'
       
-  # - template: ../templates/ui-build-and-deploy-stages.yml
-  #   parameters:
-  #     environment: 'prod'
-  #     agentPool: 'CMRC Prod Pool'
-  #     requireValidation: true
-  #     notifyUsers: $(notifyUsers)
-  #     approvers: $(approvers)
-  #     azureSubscription: 'Azure Pipeline: CMRC - Prod'
-  #     deployToSlot: true
-  #     slotName: 'stg'
+  - template: ../templates/ui-build-and-deploy-stages.yml
+    parameters:
+      environment: 'prod'
+      requireValidation: true
+      notifyUsers: $(prodNotifyUsers)
+      approvers: $(prodApprovers)
+      agentPool: 'CMRC Prod Pool'
+      azureSubscription: 'Azure Pipeline: CMRC - Prod'
+      deployToSlot: true
+      slotName: 'stg'

--- a/devops-pipelines/ui/ui-pr-build-and-test.yml
+++ b/devops-pipelines/ui/ui-pr-build-and-test.yml
@@ -92,7 +92,7 @@ stages:
             workingDirectory: '$(workingDir)'
           
           - publish: '$(workingDir)/$(covDir)/unit/index.html'
-            artifact: 'unit-coverage-report'
+            artifact: 'unit-coverage-report-$(System.JobId)'
             displayName: 'Publish Unit Test Coverage Report as Pipeline Artifact'
 
 # ---------- INTEGRATION TESTS (Playwright) ----------
@@ -129,7 +129,7 @@ stages:
             workingDirectory: '$(workingDir)'
 
           - publish: '$(workingDir)/$(covDir)/integration/index.html'
-            artifact: 'integration-coverage-report'
+            artifact: 'integration-coverage-report-$(System.JobId)'
             displayName: 'Publish integration Coverage Report as Pipeline Artifact'
           
           - script: |


### PR DESCRIPTION
1. Enable deployment jobs that target Prod
2. Set AZURE_FUNCTIONS_ENVIRONMENT app setting via deployment pipeline
3. Minor fix: Make UI unit / integration test coverage report artifact names unique per run, to enable re-running failed jobs.